### PR TITLE
📱 Set a OnClickDescription if needed

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### LbcAccessibility
+
+#### Added
+
+- `OnClickDescription` for `Composable` without `Modifier.clickable` access.
+- Update Jetpack Compose to `1.2.0-rc01`
+
+
 ## 1.1.0
 
 ### LbcTopAppBar

--- a/app/src/main/java/studio/lunabee/compose/accessibility/AccessibilityScreen.kt
+++ b/app/src/main/java/studio/lunabee/compose/accessibility/AccessibilityScreen.kt
@@ -21,6 +21,7 @@
 
 package studio.lunabee.compose.accessibility
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -29,6 +30,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
 import androidx.compose.material.Divider
 import androidx.compose.material.FloatingActionButton
@@ -44,6 +46,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -52,6 +55,7 @@ import studio.lunabee.compose.extension.topAppBarElevation
 import studio.lunabee.compose.lbcaccessibility.composable.AccessibilityCheckBoxRow
 import studio.lunabee.compose.lbcaccessibility.extension.addSemantics
 import studio.lunabee.compose.lbcaccessibility.model.AccessibilityDescription
+import studio.lunabee.compose.lbcaccessibility.model.OnClickDescription
 import studio.lunabee.compose.lbcaccessibility.model.StateDescription
 import studio.lunabee.compose.lbcaccessibility.state.AccessibilityState
 import studio.lunabee.compose.lbcaccessibility.state.rememberAccessibilityState
@@ -166,7 +170,9 @@ fun AccessibilityScreen(
                 Divider()
             }
 
-            item {
+            item(
+                key = "checkbox_accessible_item_key"
+            ) {
                 if (accessibilityState.isAccessibilityEnabled) {
                     AccessibilityCheckBoxRow(
                         initialCheckStateValue = false,
@@ -193,6 +199,39 @@ fun AccessibilityScreen(
                     }
                 } else {
                     DefaultCheckBox()
+                }
+            }
+
+            item(
+                key = "button_accessible_item_key",
+            ) {
+                val context = LocalContext.current
+                val clickAction = {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.accessibility_screen_custom_button_clicked),
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+                Button(
+                    onClick = clickAction,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(all = 8.dp)
+                        .addSemantics(
+                            accessibilityDescription = AccessibilityDescription(
+                                onClickDescription = OnClickDescription(
+                                    action = clickAction,
+                                    clickLabel = stringResource(id = R.string.accessibility_screen_custom_button_on_click_description),
+                                )
+                            )
+                        )
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.accessibility_screen_custom_button_click_me),
+                        modifier = Modifier
+                            .padding(vertical = 8.dp),
+                    )
                 }
             }
         }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -59,4 +59,8 @@
     <string name="accessibility_screen_custom_content_description_checkbox">"Je suis une CheckBox accessible"</string>
     <string name="accessibility_screen_custom_content_description_state_enabled">"Texte spécialement lu pour l'état sélectionné"</string>
     <string name="accessibility_screen_custom_content_description_state_disabled">"Texte spécialement lu pour l'état désélectionné"</string>
+    <string name="accessibility_screen_custom_button_click_me">"Je suis un bouton accessible"</string>
+    <string name="accessibility_screen_custom_button_on_click_description">"Je suis le label action du bouton"</string>
+    <string name="accessibility_screen_custom_button_clicked">"Tapé!"</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,4 +61,7 @@
     <string name="accessibility_screen_custom_content_description_checkbox">"I'm an accessible CheckBox"</string>
     <string name="accessibility_screen_custom_content_description_state_enabled">"Custom content description for enabled state"</string>
     <string name="accessibility_screen_custom_content_description_state_disabled">"Custom content description for disabled state"</string>
+    <string name="accessibility_screen_custom_button_click_me">"I'm an accessible button"</string>
+    <string name="accessibility_screen_custom_button_on_click_description">"Custom description for my click"</string>
+    <string name="accessibility_screen_custom_button_clicked">"Tapped!"</string>
 </resources>

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -26,7 +26,7 @@ object AndroidConfig {
     const val COMPILE_SDK: Int = BuildConfigs.compileSdk
     const val TARGET_SDK: Int = COMPILE_SDK
     const val MIN_SDK: Int = BuildConfigs.minSdk
-    const val BUILD_TOOLS_VERSION: String = "31.0.0"
+    const val BUILD_TOOLS_VERSION: String = "33.0.0"
 
     const val LIBRARY_URL = "https://github.com/LunabeeStudio/Lunabee_Compose_Android"
     const val GROUP_ID = "studio.lunabee.compose"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -26,7 +26,7 @@ object Modules {
 
 object BuildConfigs {
     const val lunabeeCompose: String = "1.0.0"
-    const val compileSdk: Int = 32
+    const val compileSdk: Int = 33
     const val minSdk: Int = 23
-    const val targetSdk: Int = 32
+    const val targetSdk: Int = 33
 }

--- a/lbcaccessibility/build.gradle.kts
+++ b/lbcaccessibility/build.gradle.kts
@@ -30,7 +30,7 @@ android {
 }
 
 description = "A set of methods and composable for accessibility"
-version = "1.1.0-SNAPSHOT"
+version = "1.1.0-accessibility-SNAPSHOT"
 
 publishing {
     setRepository(project)

--- a/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/extension/ModifierExt.kt
+++ b/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/extension/ModifierExt.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.text
@@ -86,6 +87,7 @@ fun Modifier.overrideSemantics(
  * Talkback will ignore elements marked with [invisibleToUser].
  */
 @ExperimentalComposeUiApi
+@Suppress("unused")
 fun Modifier.setAsInvisibleForAccessibility(): Modifier {
     return semantics {
         invisibleToUser()
@@ -129,6 +131,7 @@ fun Modifier.addSemanticsToggleable(
  *
  * @return a toggleable [Modifier] with accessibility set
  */
+@Suppress("unused")
 fun Modifier.overrideSemanticsToggleable(
     currentStateValue: Boolean,
     onStateChanged: (newStateValue: Boolean) -> Unit,
@@ -160,5 +163,15 @@ private fun SemanticsPropertyReceiver.buildSemantics(
 
     if (accessibilityDescription.isHeading) {
         heading()
+    }
+
+    accessibilityDescription.onClickDescription?.let { onClickDescription ->
+        onClick(
+            label = onClickDescription.clickLabel,
+            action = {
+                onClickDescription.action()
+                true
+            },
+        )
     }
 }

--- a/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/model/AccessibilityDescription.kt
+++ b/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/model/AccessibilityDescription.kt
@@ -21,28 +21,29 @@
 
 package studio.lunabee.compose.lbcaccessibility.model
 
-import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.heading
 
 /**
  * Object use to set parameters accessibility.
  *
- * @param text see [SemanticsPropertyReceiver.text], text of the semantics node.
+ * @param text see SemanticsPropertyReceiver.text, text of the semantics node.
  * It must be real text instead of developer-set content description.
- * @param contentDescription see [SemanticsPropertyReceiver.contentDescription], Developer-set content description of the semantics node.
+ * @param contentDescription see SemanticsPropertyReceiver.contentDescription, Developer-set content description of the semantics node.
  * If this is not set, accessibility services will present the [text] of this node as the content. This typically should not be set
  * directly by applications, because some screen readers will cease presenting other relevant information when this property is present.
  * This is intended to be used via Foundation components which are inherently intractable to automatically describe, such as Image, Icon,
  * and Canvas.
- * @param stateDescription see [SemanticsPropertyReceiver.stateDescription], developer-set state description of the semantics node.
+ * @param stateDescription see SemanticsPropertyReceiver.stateDescription, developer-set state description of the semantics node.
  * For example: on/off. If this not set, accessibility services will derive the state from other semantics properties,
  * like ProgressBarRangeInfo, but it is not guaranteed and the format will be decided by accessibility services.
  * @param isHeading indicates if your Composable should be consider as a heading. This will facilitate navigation for the user. See
  * [heading] method.
+ * @param onClickDescription see [OnClickDescription]
  */
 data class AccessibilityDescription(
     val text: String? = null,
     val contentDescription: String? = null,
     val stateDescription: StateDescription? = null,
+    val onClickDescription: OnClickDescription? = null,
     val isHeading: Boolean = false,
 )

--- a/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/model/OnClickDescription.kt
+++ b/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/model/OnClickDescription.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2022 Lunabee Studio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * OnClickDescription.kt
+ * Lunabee Compose
+ *
+ * Created by Lunabee Studio / Date - 6/21/2022 - for the Lunabee Compose library.
+ */
+
+package studio.lunabee.compose.lbcaccessibility.model
+
+/**
+ * Use this class to set a click label for accessibility if you don't have access to Modifier's clickable method.
+ *
+ * @param action action to be executed on click
+ * @param clickLabel label read by TalkBack
+ */
+data class OnClickDescription(
+    val action: () -> Unit,
+    val clickLabel: String,
+)

--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 #
-# Copyright © 2022 Lunabee Studio
+# Copyright ï¿½ 2022 Lunabee Studio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 #### suppress inspection "SpellCheckingInspection" for whole file
 #### suppress inspection "UnusedProperty" for whole file
 
-plugin.android=7.2.0
+plugin.android=7.2.1
 ## # available=7.3.0-alpha01
 ## # available=7.3.0-alpha02
 ## # available=7.3.0-alpha03
@@ -39,9 +39,16 @@ plugin.android=7.2.0
 ## # available=7.3.0-alpha08
 ## # available=7.3.0-alpha09
 ## # available=7.3.0-beta01
+## # available=7.3.0-beta02
+## # available=7.3.0-beta03
 ## # available=7.4.0-alpha01
+## # available=7.4.0-alpha02
+## # available=7.4.0-alpha03
+## # available=7.4.0-alpha04
+## # available=7.4.0-alpha05
 
 plugin.io.gitlab.arturbosch.detekt=1.20.0
+##                     # available=1.21.0-RC1
 
 version.androidx.activity=1.4.0
 ##            # available=1.5.0-alpha01
@@ -53,33 +60,31 @@ version.androidx.activity=1.4.0
 ##            # available=1.5.0-rc01
 ##            # available=1.6.0-alpha01
 ##            # available=1.6.0-alpha03
+##            # available=1.6.0-alpha05
 
-version.androidx.appcompat=1.4.1
+version.androidx.appcompat=1.4.2
 ##             # available=1.5.0-alpha01
 ##             # available=1.6.0-alpha01
 ##             # available=1.6.0-alpha03
+##             # available=1.6.0-alpha04
+##             # available=1.6.0-alpha05
 
-version.androidx.compose.compiler=1.2.0-beta01
+version.androidx.compose.compiler=1.2.0-rc01
 
-version.androidx.compose.foundation=1.2.0-beta01
+version.androidx.compose.foundation=1.2.0-rc01
 
-version.androidx.compose.material=1.2.0-beta01
+version.androidx.compose.material=1.2.0-rc01
 
-version.androidx.constraintlayout-compose=1.0.0
+version.androidx.constraintlayout-compose=1.0.1
+##                            # available=1.1.0-alpha01
+##                            # available=1.1.0-alpha02
 
-version.androidx.core=1.7.0
-##        # available=1.8.0-alpha01
-##        # available=1.8.0-alpha02
-##        # available=1.8.0-alpha03
-##        # available=1.8.0-alpha04
-##        # available=1.8.0-alpha05
-##        # available=1.8.0-alpha06
-##        # available=1.8.0-alpha07
-##        # available=1.8.0-beta01
-##        # available=1.8.0-rc01
+version.androidx.core=1.8.0
 ##        # available=1.9.0-alpha01
 ##        # available=1.9.0-alpha02
 ##        # available=1.9.0-alpha03
+##        # available=1.9.0-alpha04
+##        # available=1.9.0-alpha05
 
 version.androidx.navigation-compose=2.4.2
 ##                      # available=2.5.0-alpha01
@@ -88,6 +93,7 @@ version.androidx.navigation-compose=2.4.2
 ##                      # available=2.5.0-alpha04
 ##                      # available=2.5.0-beta01
 ##                      # available=2.5.0-rc01
+##                      # available=2.5.0-rc02
 
 version.google.accompanist=0.23.1
 ##             # available=0.24.0-alpha
@@ -99,23 +105,19 @@ version.google.accompanist=0.23.1
 ##             # available=0.24.6-alpha
 ##             # available=0.24.7-alpha
 ##             # available=0.24.8-beta
+##             # available=0.24.9-beta
+##             # available=0.24.10-beta
+##             # available=0.24.11-rc
 
 version.kotlin=1.6.21
 ## # available=1.7.0-Beta
+## # available=1.7.0-RC
+## # available=1.7.0-RC2
+## # available=1.7.0
 
-version.google.android.material=1.6.0
+version.google.android.material=1.6.1
 ##                  # available=1.7.0-alpha01
-
-plugin.org.gradle.kotlin.kotlin-dsl=2.2.0
-##                      # available=2.3.0
-##                      # available=2.3.1
-##                      # available=2.3.2
-##                      # available=2.3.3
-
-plugin.org.gradle.kotlin.kotlin-dsl.precompiled-script-plugins=2.2.0
-##                                                 # available=2.3.0
-##                                                 # available=2.3.1
-##                                                 # available=2.3.2
-##                                                 # available=2.3.3
+##                  # available=1.7.0-alpha02
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.20.0
+##                                         # available=1.21.0-RC1

--- a/versions.properties
+++ b/versions.properties
@@ -1,5 +1,5 @@
 #
-# Copyright ï¿½ 2022 Lunabee Studio
+# Copyright © 2022 Lunabee Studio
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## 📜 Description
According to the [documentation](https://developer.android.com/jetpack/compose/accessibility#add-click-labels):
> Alternatively, if you don't have access to the clickable modifier, you can set the click label in the semantics
> ```kotlin
> Modifier.semantics {
>     onClick(label = readArticleLabel, action = openArticle)
> }
> ```

👉 Add `OnClickDescription`.
👉 Add a demo in the app.
👉 Update Compose to last version.

## 💡 Motivation and Context
Use it on our project when we don't have access to `Modifier.clickable` method.

## 💚 How did you test it?

https://user-images.githubusercontent.com/72007948/174761583-e6a57acc-374f-4b0e-90dd-0d2e70520bb9.mov

## 📝 Checklist
* [x] I compiled before submitting the PR
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
