### PR TITLE
🚀 Release 1.1.0 (accessibility) and 1.2.0 (topappbar)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,12 +7,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 1.2.0
+
+### LbcTopAppBar
+
+- Update Jetpack Compose to `1.2.0-rc02`
+
+## 1.1.0
+
 ### LbcAccessibility
 
 #### Added
 
 - `OnClickDescription` for `Composable` without `Modifier.clickable` access.
-- Update Jetpack Compose to `1.2.0-rc01`
+- Update Jetpack Compose to `1.2.0-rc02`
 
 
 ## 1.1.0

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### LbcAccessibility
+
+#### Added
+
+- `OnClickDescription` for `Composable` without `Modifier.clickable` access.
+- Update Jetpack Compose to `1.2.0-rc01`
+
+
 ## 1.1.0
 
 ### LbcTopAppBar

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 
 > A set of Composable that can be used in any Android Project with Compose.
 
-This library is used in the projects we work. Its goal is to **simplify** use of Jetpack Compose.
+This Compose library is used on Lunabee Studio's projects. Its goal is to **simplify** our use of Jetpack Compose.
+To date, this library is composed of 2 distincts modules.
 
 ## Documentation
 
-Documentation can be found [here](https://github.com/LunabeeStudio/Lunabee_Compose_Android/wiki)
+The documentation of these two modules can be found [here](https://github.com/LunabeeStudio/Lunabee_Compose_Android/wiki)
 
 ## Changelog
 
@@ -17,7 +18,7 @@ Documentation can be found [here](https://github.com/LunabeeStudio/Lunabee_Compo
 
 ## Installing / Getting started
 
-You just have to clone the project. There is a demo app in order to visualize all libraries module.
+You just have to clone the project. There is a demo app in order to visualize all library's modules.
 
 ### Using it
 
@@ -32,10 +33,6 @@ maven {
 Only authorized developers with access to Sonatype will be able to publish the library on Maven central, or on the Snapshots repository.
 
 ## Contributing
-
-When you publish something open source, one of the greatest motivations is that anyone can just jump in and start contributing to your project.
-
-These paragraphs are meant to welcome those kind souls to feel that they are needed. You should state something like:
 
 If you'd like to contribute, please fork the repository and use a feature branch. Pull requests are warmly welcome.
 

--- a/app/src/main/java/studio/lunabee/compose/accessibility/AccessibilityScreen.kt
+++ b/app/src/main/java/studio/lunabee/compose/accessibility/AccessibilityScreen.kt
@@ -21,6 +21,7 @@
 
 package studio.lunabee.compose.accessibility
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -29,6 +30,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
 import androidx.compose.material.Divider
 import androidx.compose.material.FloatingActionButton
@@ -44,6 +46,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -52,6 +55,7 @@ import studio.lunabee.compose.extension.topAppBarElevation
 import studio.lunabee.compose.lbcaccessibility.composable.AccessibilityCheckBoxRow
 import studio.lunabee.compose.lbcaccessibility.extension.addSemantics
 import studio.lunabee.compose.lbcaccessibility.model.AccessibilityDescription
+import studio.lunabee.compose.lbcaccessibility.model.OnClickDescription
 import studio.lunabee.compose.lbcaccessibility.model.StateDescription
 import studio.lunabee.compose.lbcaccessibility.state.AccessibilityState
 import studio.lunabee.compose.lbcaccessibility.state.rememberAccessibilityState
@@ -166,7 +170,9 @@ fun AccessibilityScreen(
                 Divider()
             }
 
-            item {
+            item(
+                key = "checkbox_accessible_item_key"
+            ) {
                 if (accessibilityState.isAccessibilityEnabled) {
                     AccessibilityCheckBoxRow(
                         initialCheckStateValue = false,
@@ -193,6 +199,39 @@ fun AccessibilityScreen(
                     }
                 } else {
                     DefaultCheckBox()
+                }
+            }
+
+            item(
+                key = "button_accessible_item_key",
+            ) {
+                val context = LocalContext.current
+                val clickAction = {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.accessibility_screen_custom_button_clicked),
+                        Toast.LENGTH_LONG,
+                    ).show()
+                }
+                Button(
+                    onClick = clickAction,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(all = 8.dp)
+                        .addSemantics(
+                            accessibilityDescription = AccessibilityDescription(
+                                onClickDescription = OnClickDescription(
+                                    action = clickAction,
+                                    clickLabel = stringResource(id = R.string.accessibility_screen_custom_button_on_click_description),
+                                )
+                            )
+                        )
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.accessibility_screen_custom_button_click_me),
+                        modifier = Modifier
+                            .padding(vertical = 8.dp),
+                    )
                 }
             }
         }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -59,4 +59,8 @@
     <string name="accessibility_screen_custom_content_description_checkbox">"Je suis une CheckBox accessible"</string>
     <string name="accessibility_screen_custom_content_description_state_enabled">"Texte spécialement lu pour l'état sélectionné"</string>
     <string name="accessibility_screen_custom_content_description_state_disabled">"Texte spécialement lu pour l'état désélectionné"</string>
+    <string name="accessibility_screen_custom_button_click_me">"Je suis un bouton accessible"</string>
+    <string name="accessibility_screen_custom_button_on_click_description">"Je suis le label action du bouton"</string>
+    <string name="accessibility_screen_custom_button_clicked">"Tapé!"</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,4 +61,7 @@
     <string name="accessibility_screen_custom_content_description_checkbox">"I'm an accessible CheckBox"</string>
     <string name="accessibility_screen_custom_content_description_state_enabled">"Custom content description for enabled state"</string>
     <string name="accessibility_screen_custom_content_description_state_disabled">"Custom content description for disabled state"</string>
+    <string name="accessibility_screen_custom_button_click_me">"I'm an accessible button"</string>
+    <string name="accessibility_screen_custom_button_on_click_description">"Custom description for my click"</string>
+    <string name="accessibility_screen_custom_button_clicked">"Tapped!"</string>
 </resources>

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -26,7 +26,7 @@ object Modules {
 
 object BuildConfigs {
     const val lunabeeCompose: String = "1.0.0"
-    const val compileSdk: Int = 32
+    const val compileSdk: Int = 33
     const val minSdk: Int = 23
-    const val targetSdk: Int = 32
+    const val targetSdk: Int = 33
 }

--- a/lbcaccessibility/build.gradle.kts
+++ b/lbcaccessibility/build.gradle.kts
@@ -30,7 +30,7 @@ android {
 }
 
 description = "A set of methods and composable for accessibility"
-version = "1.1.0-accessibility-SNAPSHOT"
+version = "1.1.0"
 
 publishing {
     setRepository(project)

--- a/lbcaccessibility/build.gradle.kts
+++ b/lbcaccessibility/build.gradle.kts
@@ -30,7 +30,7 @@ android {
 }
 
 description = "A set of methods and composable for accessibility"
-version = "1.1.0-SNAPSHOT"
+version = "1.1.0-accessibility-SNAPSHOT"
 
 publishing {
     setRepository(project)

--- a/lbcaccessibility/build.gradle.kts
+++ b/lbcaccessibility/build.gradle.kts
@@ -29,8 +29,8 @@ android {
     resourcePrefix("lbc_acc_")
 }
 
-description = "A set methods and composable for accessibility"
-version = "1.0.0"
+description = "A set of methods and composable for accessibility"
+version = "1.1.0-SNAPSHOT"
 
 publishing {
     setRepository(project)

--- a/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/extension/ModifierExt.kt
+++ b/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/extension/ModifierExt.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.text
@@ -86,6 +87,7 @@ fun Modifier.overrideSemantics(
  * Talkback will ignore elements marked with [invisibleToUser].
  */
 @ExperimentalComposeUiApi
+@Suppress("unused")
 fun Modifier.setAsInvisibleForAccessibility(): Modifier {
     return semantics {
         invisibleToUser()
@@ -129,6 +131,7 @@ fun Modifier.addSemanticsToggleable(
  *
  * @return a toggleable [Modifier] with accessibility set
  */
+@Suppress("unused")
 fun Modifier.overrideSemanticsToggleable(
     currentStateValue: Boolean,
     onStateChanged: (newStateValue: Boolean) -> Unit,
@@ -160,5 +163,15 @@ private fun SemanticsPropertyReceiver.buildSemantics(
 
     if (accessibilityDescription.isHeading) {
         heading()
+    }
+
+    accessibilityDescription.onClickDescription?.let { onClickDescription ->
+        onClick(
+            label = onClickDescription.clickLabel,
+            action = {
+                onClickDescription.action()
+                true
+            },
+        )
     }
 }

--- a/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/model/AccessibilityDescription.kt
+++ b/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/model/AccessibilityDescription.kt
@@ -21,28 +21,29 @@
 
 package studio.lunabee.compose.lbcaccessibility.model
 
-import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.heading
 
 /**
  * Object use to set parameters accessibility.
  *
- * @param text see [SemanticsPropertyReceiver.text], text of the semantics node.
+ * @param text see SemanticsPropertyReceiver.text, text of the semantics node.
  * It must be real text instead of developer-set content description.
- * @param contentDescription see [SemanticsPropertyReceiver.contentDescription], Developer-set content description of the semantics node.
+ * @param contentDescription see SemanticsPropertyReceiver.contentDescription, Developer-set content description of the semantics node.
  * If this is not set, accessibility services will present the [text] of this node as the content. This typically should not be set
  * directly by applications, because some screen readers will cease presenting other relevant information when this property is present.
  * This is intended to be used via Foundation components which are inherently intractable to automatically describe, such as Image, Icon,
  * and Canvas.
- * @param stateDescription see [SemanticsPropertyReceiver.stateDescription], developer-set state description of the semantics node.
+ * @param stateDescription see SemanticsPropertyReceiver.stateDescription, developer-set state description of the semantics node.
  * For example: on/off. If this not set, accessibility services will derive the state from other semantics properties,
  * like ProgressBarRangeInfo, but it is not guaranteed and the format will be decided by accessibility services.
  * @param isHeading indicates if your Composable should be consider as a heading. This will facilitate navigation for the user. See
  * [heading] method.
+ * @param onClickDescription see [OnClickDescription]
  */
 data class AccessibilityDescription(
     val text: String? = null,
     val contentDescription: String? = null,
     val stateDescription: StateDescription? = null,
+    val onClickDescription: OnClickDescription? = null,
     val isHeading: Boolean = false,
 )

--- a/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/model/OnClickDescription.kt
+++ b/lbcaccessibility/src/main/java/studio/lunabee/compose/lbcaccessibility/model/OnClickDescription.kt
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * AndroidConfig.kt
+ * OnClickDescription.kt
  * Lunabee Compose
  *
- * Created by Lunabee Studio / Date - 4/8/2022 - for the Lunabee Compose library.
+ * Created by Lunabee Studio / Date - 6/21/2022 - for the Lunabee Compose library.
  */
 
-object AndroidConfig {
-    const val VERSION_CODE: Int = 1
-    const val VERSION_NAME: String = BuildConfigs.lunabeeCompose
+package studio.lunabee.compose.lbcaccessibility.model
 
-    const val COMPILE_SDK: Int = BuildConfigs.compileSdk
-    const val TARGET_SDK: Int = COMPILE_SDK
-    const val MIN_SDK: Int = BuildConfigs.minSdk
-    const val BUILD_TOOLS_VERSION: String = "33.0.0"
-
-    const val LIBRARY_URL = "https://github.com/LunabeeStudio/Lunabee_Compose_Android"
-    const val GROUP_ID = "studio.lunabee.compose"
-}
+/**
+ * Use this class to set a click label for accessibility if you don't have access to Modifier's clickable method.
+ *
+ * @param action action to be executed on click
+ * @param clickLabel label read by TalkBack
+ */
+data class OnClickDescription(
+    val action: () -> Unit,
+    val clickLabel: String,
+)

--- a/lbctopappbar/build.gradle.kts
+++ b/lbctopappbar/build.gradle.kts
@@ -30,7 +30,7 @@ android {
 }
 
 description = "A set of TopAppBar to be used in any Jetpack Compose app."
-version = "1.1.0"
+version = "1.2.0-SNAPSHOT"
 
 publishing {
     setRepository(project)

--- a/lbctopappbar/build.gradle.kts
+++ b/lbctopappbar/build.gradle.kts
@@ -30,7 +30,7 @@ android {
 }
 
 description = "A set of TopAppBar to be used in any Jetpack Compose app."
-version = "1.2.0-SNAPSHOT"
+version = "1.2.0"
 
 publishing {
     setRepository(project)

--- a/versions.properties
+++ b/versions.properties
@@ -41,6 +41,7 @@ plugin.android=7.2.1
 ## # available=7.3.0-beta01
 ## # available=7.3.0-beta02
 ## # available=7.3.0-beta03
+## # available=7.3.0-beta04
 ## # available=7.4.0-alpha01
 ## # available=7.4.0-alpha02
 ## # available=7.4.0-alpha03
@@ -69,11 +70,11 @@ version.androidx.appcompat=1.4.2
 ##             # available=1.6.0-alpha04
 ##             # available=1.6.0-alpha05
 
-version.androidx.compose.compiler=1.2.0-rc01
+version.androidx.compose.compiler=1.2.0-rc02
 
-version.androidx.compose.foundation=1.2.0-rc01
+version.androidx.compose.foundation=1.2.0-rc02
 
-version.androidx.compose.material=1.2.0-rc01
+version.androidx.compose.material=1.2.0-rc02
 
 version.androidx.constraintlayout-compose=1.0.1
 ##                            # available=1.1.0-alpha01
@@ -108,6 +109,7 @@ version.google.accompanist=0.23.1
 ##             # available=0.24.9-beta
 ##             # available=0.24.10-beta
 ##             # available=0.24.11-rc
+##             # available=0.24.12-rc
 
 version.kotlin=1.6.21
 ## # available=1.7.0-Beta

--- a/versions.properties
+++ b/versions.properties
@@ -28,7 +28,7 @@
 #### suppress inspection "SpellCheckingInspection" for whole file
 #### suppress inspection "UnusedProperty" for whole file
 
-plugin.android=7.2.0
+plugin.android=7.2.1
 ## # available=7.3.0-alpha01
 ## # available=7.3.0-alpha02
 ## # available=7.3.0-alpha03
@@ -39,9 +39,16 @@ plugin.android=7.2.0
 ## # available=7.3.0-alpha08
 ## # available=7.3.0-alpha09
 ## # available=7.3.0-beta01
+## # available=7.3.0-beta02
+## # available=7.3.0-beta03
 ## # available=7.4.0-alpha01
+## # available=7.4.0-alpha02
+## # available=7.4.0-alpha03
+## # available=7.4.0-alpha04
+## # available=7.4.0-alpha05
 
 plugin.io.gitlab.arturbosch.detekt=1.20.0
+##                     # available=1.21.0-RC1
 
 version.androidx.activity=1.4.0
 ##            # available=1.5.0-alpha01
@@ -53,33 +60,31 @@ version.androidx.activity=1.4.0
 ##            # available=1.5.0-rc01
 ##            # available=1.6.0-alpha01
 ##            # available=1.6.0-alpha03
+##            # available=1.6.0-alpha05
 
-version.androidx.appcompat=1.4.1
+version.androidx.appcompat=1.4.2
 ##             # available=1.5.0-alpha01
 ##             # available=1.6.0-alpha01
 ##             # available=1.6.0-alpha03
+##             # available=1.6.0-alpha04
+##             # available=1.6.0-alpha05
 
-version.androidx.compose.compiler=1.2.0-beta01
+version.androidx.compose.compiler=1.2.0-rc01
 
-version.androidx.compose.foundation=1.2.0-beta01
+version.androidx.compose.foundation=1.2.0-rc01
 
-version.androidx.compose.material=1.2.0-beta01
+version.androidx.compose.material=1.2.0-rc01
 
-version.androidx.constraintlayout-compose=1.0.0
+version.androidx.constraintlayout-compose=1.0.1
+##                            # available=1.1.0-alpha01
+##                            # available=1.1.0-alpha02
 
-version.androidx.core=1.7.0
-##        # available=1.8.0-alpha01
-##        # available=1.8.0-alpha02
-##        # available=1.8.0-alpha03
-##        # available=1.8.0-alpha04
-##        # available=1.8.0-alpha05
-##        # available=1.8.0-alpha06
-##        # available=1.8.0-alpha07
-##        # available=1.8.0-beta01
-##        # available=1.8.0-rc01
+version.androidx.core=1.8.0
 ##        # available=1.9.0-alpha01
 ##        # available=1.9.0-alpha02
 ##        # available=1.9.0-alpha03
+##        # available=1.9.0-alpha04
+##        # available=1.9.0-alpha05
 
 version.androidx.navigation-compose=2.4.2
 ##                      # available=2.5.0-alpha01
@@ -88,6 +93,7 @@ version.androidx.navigation-compose=2.4.2
 ##                      # available=2.5.0-alpha04
 ##                      # available=2.5.0-beta01
 ##                      # available=2.5.0-rc01
+##                      # available=2.5.0-rc02
 
 version.google.accompanist=0.23.1
 ##             # available=0.24.0-alpha
@@ -99,23 +105,19 @@ version.google.accompanist=0.23.1
 ##             # available=0.24.6-alpha
 ##             # available=0.24.7-alpha
 ##             # available=0.24.8-beta
+##             # available=0.24.9-beta
+##             # available=0.24.10-beta
+##             # available=0.24.11-rc
 
 version.kotlin=1.6.21
 ## # available=1.7.0-Beta
+## # available=1.7.0-RC
+## # available=1.7.0-RC2
+## # available=1.7.0
 
-version.google.android.material=1.6.0
+version.google.android.material=1.6.1
 ##                  # available=1.7.0-alpha01
-
-plugin.org.gradle.kotlin.kotlin-dsl=2.2.0
-##                      # available=2.3.0
-##                      # available=2.3.1
-##                      # available=2.3.2
-##                      # available=2.3.3
-
-plugin.org.gradle.kotlin.kotlin-dsl.precompiled-script-plugins=2.2.0
-##                                                 # available=2.3.0
-##                                                 # available=2.3.1
-##                                                 # available=2.3.2
-##                                                 # available=2.3.3
+##                  # available=1.7.0-alpha02
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.20.0
+##                                         # available=1.21.0-RC1


### PR DESCRIPTION
## 📜 Description
Release new version of `lbcaccessibility` module with:
👉 Compose version set to `1.2.0-rc02`
👉 New object to handle click description for Composable without `Modifier.clickable` option.

Release new version of `lbctopappbar` module with:
👉 Compose version set to `1.2.0-rc02`

## 💡 Motivation and Context
👉 Need to handle click description in our project.
👉 Keep Compose up-to-date.

## 💚 How did you test it?
👉 Run the demo app.
👉 Test in our app with snapshot version.

## 📝 Checklist
* [x] I compiled before submitting the PR
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
