### PR TITLE
🚀 Release with new Jetpack Compose version

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,12 +7,34 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 1.3.0
+
+### LbcTopAppBar
+
+- Update Jetpack Compose to `1.2.0` and Kotlin to `1.7.0`
+
+## 1.2.0
+
+### LbcAccessibility
+
+#### Added
+
+- Update Jetpack Compose to `1.2.0`  and Kotlin to `1.7.0`
+
+## 1.2.0
+
+### LbcTopAppBar
+
+- Update Jetpack Compose to `1.2.0-rc02`
+
+## 1.1.0
+
 ### LbcAccessibility
 
 #### Added
 
 - `OnClickDescription` for `Composable` without `Modifier.clickable` access.
-- Update Jetpack Compose to `1.2.0-rc01`
+- Update Jetpack Compose to `1.2.0-rc02`
 
 
 ## 1.1.0

--- a/lbcaccessibility/build.gradle.kts
+++ b/lbcaccessibility/build.gradle.kts
@@ -30,7 +30,7 @@ android {
 }
 
 description = "A set of methods and composable for accessibility"
-version = "1.1.0-accessibility-SNAPSHOT"
+version = "1.2.0"
 
 publishing {
     setRepository(project)

--- a/lbctopappbar/build.gradle.kts
+++ b/lbctopappbar/build.gradle.kts
@@ -30,7 +30,7 @@ android {
 }
 
 description = "A set of TopAppBar to be used in any Jetpack Compose app."
-version = "1.2.0-SNAPSHOT"
+version = "1.3.0"
 
 publishing {
     setRepository(project)

--- a/versions.properties
+++ b/versions.properties
@@ -41,23 +41,22 @@ plugin.android=7.2.1
 ## # available=7.3.0-beta01
 ## # available=7.3.0-beta02
 ## # available=7.3.0-beta03
+## # available=7.3.0-beta04
+## # available=7.3.0-beta05
 ## # available=7.4.0-alpha01
 ## # available=7.4.0-alpha02
 ## # available=7.4.0-alpha03
 ## # available=7.4.0-alpha04
 ## # available=7.4.0-alpha05
+## # available=7.4.0-alpha06
+## # available=7.4.0-alpha07
+## # available=7.4.0-alpha08
 
 plugin.io.gitlab.arturbosch.detekt=1.20.0
 ##                     # available=1.21.0-RC1
+##                     # available=1.21.0-RC2
 
-version.androidx.activity=1.4.0
-##            # available=1.5.0-alpha01
-##            # available=1.5.0-alpha02
-##            # available=1.5.0-alpha03
-##            # available=1.5.0-alpha04
-##            # available=1.5.0-alpha05
-##            # available=1.5.0-beta01
-##            # available=1.5.0-rc01
+version.androidx.activity=1.5.0
 ##            # available=1.6.0-alpha01
 ##            # available=1.6.0-alpha03
 ##            # available=1.6.0-alpha05
@@ -69,15 +68,18 @@ version.androidx.appcompat=1.4.2
 ##             # available=1.6.0-alpha04
 ##             # available=1.6.0-alpha05
 
-version.androidx.compose.compiler=1.2.0-rc01
+version.androidx.compose.compiler=1.2.0
 
-version.androidx.compose.foundation=1.2.0-rc01
+version.androidx.compose.foundation=1.2.0-rc03
+##                      # available=1.3.0-alpha01
 
-version.androidx.compose.material=1.2.0-rc01
+version.androidx.compose.material=1.2.0-rc03
+##                    # available=1.3.0-alpha01
 
 version.androidx.constraintlayout-compose=1.0.1
 ##                            # available=1.1.0-alpha01
 ##                            # available=1.1.0-alpha02
+##                            # available=1.1.0-alpha03
 
 version.androidx.core=1.8.0
 ##        # available=1.9.0-alpha01
@@ -86,14 +88,7 @@ version.androidx.core=1.8.0
 ##        # available=1.9.0-alpha04
 ##        # available=1.9.0-alpha05
 
-version.androidx.navigation-compose=2.4.2
-##                      # available=2.5.0-alpha01
-##                      # available=2.5.0-alpha02
-##                      # available=2.5.0-alpha03
-##                      # available=2.5.0-alpha04
-##                      # available=2.5.0-beta01
-##                      # available=2.5.0-rc01
-##                      # available=2.5.0-rc02
+version.androidx.navigation-compose=2.5.0
 
 version.google.accompanist=0.23.1
 ##             # available=0.24.0-alpha
@@ -108,12 +103,11 @@ version.google.accompanist=0.23.1
 ##             # available=0.24.9-beta
 ##             # available=0.24.10-beta
 ##             # available=0.24.11-rc
+##             # available=0.24.12-rc
+##             # available=0.24.13-rc
 
-version.kotlin=1.6.21
-## # available=1.7.0-Beta
-## # available=1.7.0-RC
-## # available=1.7.0-RC2
-## # available=1.7.0
+version.kotlin=1.7.0
+## # available=1.7.10
 
 version.google.android.material=1.6.1
 ##                  # available=1.7.0-alpha01
@@ -121,3 +115,4 @@ version.google.android.material=1.6.1
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.20.0
 ##                                         # available=1.21.0-RC1
+##                                         # available=1.21.0-RC2


### PR DESCRIPTION
## 📜 Description
Jetpack Compose to 1.2.0 and Kotlin 1.7.0.
I skip a little step, version was already set (SNAPSHOT was removed in the previous PR)

## 💡 Motivation and Context
Keep project up-to-date.

## 💚 How did you test it?
-

## 📝 Checklist
* [x] I compiled before submitting the PR
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
