### PR TITLE
Feature/safer root print

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,7 +7,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### LbcAndroidTest
+
+- Catch root print error more precisely, and don't rethrow when the screenshot failed
+
 ### All (LbcAccessibility 1.5.0, lbcAndroidTest 1.2.0, LbcCore 1.1.0, LbcFoundation 1.1.0, LbcTheme 1.1.0, MaterialColorUtilities 1.1.0)
+
 - Update dependencies
 - Rename source dirs from `java` to `kotlin`
 - Use precompiled plugin for publishing
@@ -15,6 +20,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## 1.2.0
 
 ### LbcAndroidTest
+
 - Add params `deleteOnSuccess` and `appendTimestamp` to `LbcPrintRule`
 - Allow client to choose between internal or public storage for `LbcPrintRule`
 - Rework `LbcPrintRule` constructor with `internalStorage` and `publicStorage` factories
@@ -39,6 +45,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - New module for Android Compose testing.
 
 ### LbcCore
+
 - Add a method to get string with context in `LbcTextSpec`
 - Add a sealed class of `LbcTextSpec` to find string in resource by name
 

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -35,7 +35,7 @@ object AndroidConfig {
 
     const val LBC_CORE_VERSION: String = "1.1.0"
     const val LBC_FOUNDATION_VERSION: String = "1.1.0"
-    const val LBC_ANDROID_TEST_VERSION: String = "1.2.0"
+    const val LBC_ANDROID_TEST_VERSION: String = "1.2.1"
     const val LBC_ACCESSIBILITY_VERSION: String = "1.5.0"
     const val LBC_THEME_VERSION: String = "1.1.0"
     const val MATERIAL_COLOR_UTILITIES_VERSION: String = "1.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,8 +42,9 @@ android-gradle-plugin = "8.2.2"
 ##                 ⬆ = "8.4.0-alpha04"
 ##                 ⬆ = "8.4.0-alpha05"
 ##                 ⬆ = "8.4.0-alpha06"
+##                 ⬆ = "8.4.0-alpha07"
 
-detekt = "1.23.4"
+detekt = "1.23.5"
 
 androidx-test-runner = "1.5.2"
 ##                ⬆ = "1.5.3-alpha01"
@@ -52,6 +53,7 @@ androidx-test-runner = "1.5.2"
 ##                ⬆ = "1.6.0-alpha03"
 ##                ⬆ = "1.6.0-alpha04"
 ##                ⬆ = "1.6.0-alpha05"
+##                ⬆ = "1.6.0-alpha06"
 
 # Used to set kotlinCompilerExtensionVersion
 compose-compiler = "1.5.8"

--- a/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/LbcAndroidTestConstants.kt
+++ b/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/LbcAndroidTestConstants.kt
@@ -44,4 +44,9 @@ object LbcAndroidTestConstants {
      * Suffix for any failure at the end of test
      */
     const val FailureSuffix: String = "_FAILURE"
+
+    /**
+     * Suffix when root capture fallback to whole screen (due to many roots)
+     */
+    const val ManyRootsSuffix: String = "_MANY_ROOTS"
 }

--- a/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
+++ b/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
@@ -155,6 +155,9 @@ fun SemanticsMatcher.waitAndPrintRootToCacheDir(
     } catch (e: ComposeTimeoutException) {
         printRoot(useUnmergedTree = useUnmergedTree, printRule, "${suffix}${LbcAndroidTestConstants.TimeoutSuffix}")
         throw e
+    } catch (e: AssertionError) {
+        printRoot(useUnmergedTree = useUnmergedTree, printRule, "${suffix}${LbcAndroidTestConstants.ErrorSuffix}")
+        throw e
     }
 }
 

--- a/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
+++ b/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
@@ -150,15 +150,24 @@ fun SemanticsMatcher.waitAndPrintRootToCacheDir(
 ): SemanticsNodeInteraction {
     return try {
         waitUntilExactlyOneExists(useUnmergedTree, timeout)
-        onRoot().printToCacheDir(printRule, suffix)
+        printRoot(useUnmergedTree, printRule, suffix)
         onNode(this)
     } catch (e: ComposeTimeoutException) {
-        onRoot(useUnmergedTree = useUnmergedTree)
-            .printToCacheDir(printRule, "${suffix}${LbcAndroidTestConstants.TimeoutSuffix}")
+        printRoot(useUnmergedTree = useUnmergedTree, printRule, "${suffix}${LbcAndroidTestConstants.TimeoutSuffix}")
         throw e
+    }
+}
+
+@OptIn(ExperimentalTestApi::class)
+private fun ComposeUiTest.printRoot(
+    useUnmergedTree: Boolean,
+    printRule: LbcPrintRule,
+    suffix: String,
+) {
+    try {
+        onRoot(useUnmergedTree = useUnmergedTree).printToCacheDir(printRule, suffix)
     } catch (e: AssertionError) {
-        printRule.printWholeScreen(suffix = "${suffix}${LbcAndroidTestConstants.ErrorSuffix}")
-        throw e
+        printRule.printWholeScreen(suffix = "${suffix}${LbcAndroidTestConstants.ManyRootsSuffix}")
     }
 }
 


### PR DESCRIPTION
## 📜 Description
- Rework the print fallback to avoid re-throwing when the screenshot failed (but not the test)

## 💡 Motivation and Context
- Safer test print, see previous PR #43 

## 💚 How did you test it?

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
