### PR TITLE
Feature/annotated getter

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -8,11 +8,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### All
+
 - Fix Kotlin sources not published anymore on Maven
 
 ### LbcAndroidTest
 
 - Catch root print error more precisely, and don't rethrow when the screenshot failed
+
+### LbcCore
+
+- Add `fun annotated(context: Context): AnnotatedString` in `LbcTextSpec` to retrieve `AnnotatedString` directly
 
 ### All (LbcAccessibility 1.5.0, lbcAndroidTest 1.2.0, LbcCore 1.1.0, LbcFoundation 1.1.0, LbcTheme 1.1.0, MaterialColorUtilities 1.1.0)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ kotlin = "1.9.22"
 ##  ⬆ = "2.0.0-Beta1"
 ##  ⬆ = "2.0.0-Beta2"
 ##  ⬆ = "2.0.0-Beta3"
+##  ⬆ = "2.0.0-Beta4"
 
 android-gradle-plugin = "8.2.2"
 ##                 ⬆ = "8.3.0-alpha01"
@@ -37,6 +38,7 @@ android-gradle-plugin = "8.2.2"
 ##                 ⬆ = "8.3.0-beta01"
 ##                 ⬆ = "8.3.0-beta02"
 ##                 ⬆ = "8.3.0-rc01"
+##                 ⬆ = "8.3.0-rc02"
 ##                 ⬆ = "8.4.0-alpha01"
 ##                 ⬆ = "8.4.0-alpha02"
 ##                 ⬆ = "8.4.0-alpha03"
@@ -45,6 +47,8 @@ android-gradle-plugin = "8.2.2"
 ##                 ⬆ = "8.4.0-alpha06"
 ##                 ⬆ = "8.4.0-alpha07"
 ##                 ⬆ = "8.4.0-alpha08"
+##                 ⬆ = "8.4.0-alpha09"
+##                 ⬆ = "8.4.0-alpha10"
 
 detekt = "1.23.5"
 
@@ -58,9 +62,9 @@ androidx-test-runner = "1.5.2"
 ##                ⬆ = "1.6.0-alpha06"
 
 # Used to set kotlinCompilerExtensionVersion
-compose-compiler = "1.5.8"
+compose-compiler = "1.5.10"
 
-compose-bom = "2024.01.00"
+compose-bom = "2024.02.01"
 
 junit-junit = "4.13.2"
 
@@ -81,13 +85,17 @@ androidx-core = "1.12.0"
 ##         ⬆ = "1.13.0-alpha02"
 ##         ⬆ = "1.13.0-alpha03"
 ##         ⬆ = "1.13.0-alpha04"
+##         ⬆ = "1.13.0-alpha05"
 
 androidx-activity = "1.8.2"
 ##             ⬆ = "1.9.0-alpha01"
 ##             ⬆ = "1.9.0-alpha02"
+##             ⬆ = "1.9.0-alpha03"
 
-androidx-navigation = "2.7.6"
+androidx-navigation = "2.7.7"
 ##               ⬆ = "2.8.0-alpha01"
+##               ⬆ = "2.8.0-alpha02"
+##               ⬆ = "2.8.0-alpha03"
 
 [libraries]
 

--- a/lbccore/src/androidTest/kotlin/studio/lunabee/compose/core/LbcTextSpecTest.kt
+++ b/lbccore/src/androidTest/kotlin/studio/lunabee/compose/core/LbcTextSpecTest.kt
@@ -42,9 +42,10 @@ class LbcTextSpecTest {
     fun raw_test() {
         val expected = "test"
         val textSpec = LbcTextSpec.Raw(value = expected)
+        assertEquals(expected, textSpec.string(context))
+        assertEquals(AnnotatedString(expected), textSpec.annotated(context))
         composeTestRule.setContent {
             assertEquals(expected, textSpec.string)
-            assertEquals(expected, textSpec.string(context))
             assertEquals(AnnotatedString(expected), textSpec.annotated)
         }
     }
@@ -55,9 +56,10 @@ class LbcTextSpecTest {
         val test = "test %s"
         val expected = test.format(param)
         val textSpec = LbcTextSpec.Raw(value = test, param)
+        assertEquals(expected, textSpec.string(context))
+        assertEquals(AnnotatedString(expected), textSpec.annotated(context))
         composeTestRule.setContent {
             assertEquals(expected, textSpec.string)
-            assertEquals(expected, textSpec.string(context))
             assertEquals(AnnotatedString(expected), textSpec.annotated)
         }
     }
@@ -66,10 +68,11 @@ class LbcTextSpecTest {
     fun annotated_test() {
         val expected = AnnotatedString("test")
         val textSpec = LbcTextSpec.Annotated(value = expected)
+        assertEquals(expected, textSpec.annotated(context))
+        assertEquals(expected.text, textSpec.string(context))
         composeTestRule.setContent {
             assertEquals(expected, textSpec.annotated)
             assertEquals(expected.text, textSpec.string)
-            assertEquals(expected.text, textSpec.string(context))
         }
     }
 
@@ -85,11 +88,13 @@ class LbcTextSpecTest {
             .getString(studio.lunabee.compose.core.test.R.string.test_args, stringParam, intParam)
         val actualTestArgs = LbcTextSpec.StringResource(id = studio.lunabee.compose.core.test.R.string.test_args, stringParam, intParam)
 
+        assertEquals(expectedTest, actualTest.string(context))
+        assertEquals(expectedTestArgs, actualTestArgs.string(context))
+        assertEquals(AnnotatedString(expectedTest), actualTest.annotated(context))
+        assertEquals(AnnotatedString(expectedTestArgs), actualTestArgs.annotated(context))
         composeTestRule.setContent {
             assertEquals(expectedTest, actualTest.string)
-            assertEquals(expectedTest, actualTest.string(context))
             assertEquals(expectedTestArgs, actualTestArgs.string)
-            assertEquals(expectedTestArgs, actualTestArgs.string(context))
 
             assertEquals(AnnotatedString(expectedTest), actualTest.annotated)
             assertEquals(AnnotatedString(expectedTestArgs), actualTestArgs.annotated)
@@ -109,9 +114,10 @@ class LbcTextSpecTest {
         )
         val actualTestArgs = LbcTextSpec.StringResource(studio.lunabee.compose.core.test.R.string.test_args, stringParamTextSpec, intParam)
 
+        assertEquals(expectedTestArgs, actualTestArgs.string(context))
+        assertEquals(AnnotatedString(expectedTestArgs), actualTestArgs.annotated(context))
         composeTestRule.setContent {
             assertEquals(expectedTestArgs, actualTestArgs.string)
-            assertEquals(expectedTestArgs, actualTestArgs.string(context))
             assertEquals(AnnotatedString(expectedTestArgs), actualTestArgs.annotated)
         }
     }
@@ -130,11 +136,13 @@ class LbcTextSpecTest {
             .getQuantityString(studio.lunabee.compose.core.test.R.plurals.test_args_plural, 2, 2)
         val actualTestMany = LbcTextSpec.PluralsResource(studio.lunabee.compose.core.test.R.plurals.test_args_plural, 2, 2)
 
+        assertEquals(expectedTestOne, actualTestOne.string(context))
+        assertEquals(expectedTestMany, actualTestMany.string(context))
+        assertEquals(AnnotatedString(expectedTestOne), actualTestOne.annotated(context))
+        assertEquals(AnnotatedString(expectedTestMany), actualTestMany.annotated(context))
         composeTestRule.setContent {
             assertEquals(expectedTestOne, actualTestOne.string)
-            assertEquals(expectedTestOne, actualTestOne.string(context))
             assertEquals(expectedTestMany, actualTestMany.string)
-            assertEquals(expectedTestMany, actualTestMany.string(context))
 
             assertEquals(AnnotatedString(expectedTestOne), actualTestOne.annotated)
             assertEquals(AnnotatedString(expectedTestMany), actualTestMany.annotated)
@@ -168,15 +176,19 @@ class LbcTextSpecTest {
             intParam,
         )
 
+        assertEquals(expectedTest, actualTest.string(context))
+        assertEquals(expectedTest, actualFallbackTest.string(context))
+        assertEquals(expectedTestArgs, actualTestArgs.string(context))
+        assertEquals(expectedTestArgs, actualTestFallbackArgs.string(context))
+        assertEquals(AnnotatedString(expectedTest), actualTest.annotated(context))
+        assertEquals(AnnotatedString(expectedTest), actualFallbackTest.annotated(context))
+        assertEquals(AnnotatedString(expectedTestArgs), actualTestArgs.annotated(context))
+        assertEquals(AnnotatedString(expectedTestArgs), actualTestFallbackArgs.annotated(context))
         composeTestRule.setContent {
             assertEquals(expectedTest, actualTest.string)
-            assertEquals(expectedTest, actualTest.string(context))
             assertEquals(expectedTest, actualFallbackTest.string)
-            assertEquals(expectedTest, actualFallbackTest.string(context))
             assertEquals(expectedTestArgs, actualTestArgs.string)
-            assertEquals(expectedTestArgs, actualTestArgs.string(context))
             assertEquals(expectedTestArgs, actualTestFallbackArgs.string)
-            assertEquals(expectedTestArgs, actualTestFallbackArgs.string(context))
 
             assertEquals(AnnotatedString(expectedTest), actualTest.annotated)
             assertEquals(AnnotatedString(expectedTest), actualFallbackTest.annotated)

--- a/lbccore/src/main/kotlin/studio/lunabee/compose/core/LbcTextSpec.kt
+++ b/lbccore/src/main/kotlin/studio/lunabee/compose/core/LbcTextSpec.kt
@@ -44,6 +44,7 @@ sealed class LbcTextSpec {
         get
 
     abstract fun string(context: Context): String
+    open fun annotated(context: Context): AnnotatedString = AnnotatedString(string(context))
 
     @Composable
     @ReadOnlyComposable
@@ -127,6 +128,8 @@ sealed class LbcTextSpec {
             get() = value.text
 
         override fun string(context: Context): String = value.text
+
+        override fun annotated(context: Context): AnnotatedString = this.value
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true


### PR DESCRIPTION
## 📜 Description
- Add `LbcTextSpec` shortcut function to get an `AnnotatedString` from the context

## 💡 Motivation and Context
- Semantics text requires AnnotatedString and are note composable
 -> avoid `this.text = AnnotatedString(description.string(context))`

## 💚 How did you test it?
- Unit tests

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
