### PR TITLE
feature/factorize_publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ captures/
 # Comment next line if keeping position of elements in Navigation Editor is relevant for you
 .idea/navEditor.xml
 .idea/codeStyles/codeStyleConfig.xml
+.idea/deploymentTargetSelector.xml
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### All
 
 - Fix Kotlin sources not published anymore on Maven
+- Add `publishList` Gradle task to get all module to publish from CI
 
 ### LbcAndroidTest
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,3 +62,12 @@ tasks.withType<io.gitlab.arturbosch.detekt.Detekt> {
         html.outputLocation.set(file("${layout.buildDirectory.asFile.get().path}/reports/detekt/detekt-report.html"))
     }
 }
+
+tasks.create("publishList") {
+    doLast {
+        val publishProjects = project.allprojects.filter {
+            it.tasks.findByName("publish") != null
+        }.joinToString(";") { it.name }
+        println(publishProjects)
+    }
+}

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -33,11 +33,12 @@ object AndroidConfig {
     const val LIBRARY_URL: String = "https://github.com/LunabeeStudio/Lunabee_Compose_Android"
     const val GROUP_ID: String = "studio.lunabee.compose"
 
-    const val LBC_CORE_VERSION: String = "1.1.0"
-    const val LBC_FOUNDATION_VERSION: String = "1.1.0"
-    const val LBC_ANDROID_TEST_VERSION: String = "1.2.1"
-    const val LBC_ACCESSIBILITY_VERSION: String = "1.5.0"
-    const val LBC_THEME_VERSION: String = "1.1.0"
+    // ⚠️ Match module name in UPPER_CASE ('-' -> '_')
+    const val LBCCORE_VERSION: String = "1.1.0"
+    const val LBCFOUNDATION_VERSION: String = "1.1.0"
+    const val LBCANDROIDTEST_VERSION: String = "1.2.1"
+    const val LBCACCESSIBILITY_VERSION: String = "1.5.0"
+    const val LBCTHEME_VERSION: String = "1.1.0"
     const val MATERIAL_COLOR_UTILITIES_VERSION: String = "1.1.0"
 
     val JDK_VERSION: JavaVersion = JavaVersion.VERSION_17

--- a/lbcaccessibility/build.gradle.kts
+++ b/lbcaccessibility/build.gradle.kts
@@ -34,7 +34,7 @@ android {
 }
 
 description = "A set of methods and composable for accessibility"
-version = AndroidConfig.LBC_ACCESSIBILITY_VERSION
+version = AndroidConfig.LBCACCESSIBILITY_VERSION
 
 dependencies {
     implementation(platform(libs.compose.bom))

--- a/lbcandroidtest/build.gradle.kts
+++ b/lbcandroidtest/build.gradle.kts
@@ -31,8 +31,8 @@ android {
     kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
 }
 
-description = "Tools for developping android test"
-version = AndroidConfig.LBC_ANDROID_TEST_VERSION
+description = "Tools for developing android test"
+version = AndroidConfig.LBCANDROIDTEST_VERSION
 
 dependencies {
     implementation(platform(libs.compose.bom))

--- a/lbccore/build.gradle.kts
+++ b/lbccore/build.gradle.kts
@@ -34,7 +34,7 @@ android {
 }
 
 description = "A set of tools for Compose"
-version = AndroidConfig.LBC_CORE_VERSION
+version = AndroidConfig.LBCCORE_VERSION
 
 dependencies {
     implementation(platform(libs.compose.bom))

--- a/lbcfoundation/build.gradle.kts
+++ b/lbcfoundation/build.gradle.kts
@@ -34,7 +34,7 @@ android {
 }
 
 description = "A set of custom components from androidx.composable.foundation"
-version = AndroidConfig.LBC_FOUNDATION_VERSION
+version = AndroidConfig.LBCFOUNDATION_VERSION
 
 dependencies {
     implementation(platform(libs.compose.bom))

--- a/lbctheme/build.gradle.kts
+++ b/lbctheme/build.gradle.kts
@@ -34,7 +34,7 @@ android {
 }
 
 description = "Function to build dynamic theme with Material3 algorithm"
-version = AndroidConfig.LBC_THEME_VERSION
+version = AndroidConfig.LBCTHEME_VERSION
 
 dependencies {
     implementation(platform(libs.compose.bom))


### PR DESCRIPTION
## 📜 Description
- Add `publishList` Gradle task to get all module to publish from CI
It prints the list of module which have the publish task separated by `;`. This way we can get the list from the bash script on the CI.

## 💡 Motivation and Context
- Avoid the need to manually add the new module in the CI script
See publish steps https://ci-android.lunabee.studio/admin/editBuildRunners.html?id=buildType:LunabeeStudio_Android_LunabeeComposeAndroid_Publish

## 💚 How did you test it?
- https://ci-android.lunabee.studio/buildConfiguration/LunabeeStudio_Android_LunabeeComposeAndroid_Publish/24511?buildTab=log&focusLine=0&logView=flowAware&linesState=124
- Check snapshot artifact on maven https://s01.oss.sonatype.org/content/repositories/snapshots/studio/lunabee/compose/

## 📝 Checklist
* [ ] I reviewed the submitted code
* [ ] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
