### PR TITLE
🏔 Update to K2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## 2024-06-06
+
+- Migrate to K2 🏔️
+
 ## 2024-03-28
 
 ```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,7 @@
 plugins {
     id("com.android.application")
     id("kotlin-android")
+    id(libs.plugins.compose.plugin.get().pluginId)
 }
 
 android {
@@ -43,11 +44,6 @@ android {
     compileOptions {
         sourceCompatibility = AndroidConfig.JDK_VERSION
         targetCompatibility = AndroidConfig.JDK_VERSION
-    }
-
-    buildFeatures.compose = true
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
     buildTypes {
@@ -109,11 +105,7 @@ dependencies {
     debugImplementation(libs.compose.ui.test.manifest)
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
-    kotlinOptions {
-        jvmTarget = AndroidConfig.JDK_VERSION.toString()
-    }
-}
+kotlin.compilerOptions.jvmTarget.set(AndroidConfig.JVM_TARGET)
 
 java {
     toolchain {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -32,6 +32,7 @@ repositories {
 dependencies {
     implementation(libs.android.gradle.plugin)
     implementation(libs.kotlin.gradle.plugin)
+    implementation(libs.compose.plugin)
 
     implementation(gradleApi())
     implementation(localGroovy())

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -1,4 +1,5 @@
 import org.gradle.api.JavaVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 /*
  * Copyright © 2022 Lunabee Studio
@@ -45,4 +46,5 @@ object AndroidConfig {
     const val LBCIMAGE_VERSION: String = "1.0.0"
 
     val JDK_VERSION: JavaVersion = JavaVersion.VERSION_17
+    val JVM_TARGET: JvmTarget = JvmTarget.JVM_17
 }

--- a/buildSrc/src/main/kotlin/lunabee.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/lunabee.android-library-conventions.gradle.kts
@@ -24,6 +24,7 @@ import org.gradle.accessors.dm.LibrariesForLibs
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 group = AndroidConfig.GROUP_ID
@@ -40,11 +41,6 @@ android {
         @Suppress("DEPRECATION") // https://stackoverflow.com/questions/76084080/apply-targetsdk-in-android-instrumentation-test
         targetSdk = AndroidConfig.TARGET_SDK
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildFeatures.compose = true
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
     }
 
     compileOptions {
@@ -64,11 +60,7 @@ dependencies {
     androidTestImplementation(libs.androidx.test.runner)
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
-    kotlinOptions {
-        jvmTarget = AndroidConfig.JDK_VERSION.toString()
-    }
-}
+kotlin.compilerOptions.jvmTarget.set(AndroidConfig.JVM_TARGET)
 
 java {
     toolchain {

--- a/buildSrc/src/main/kotlin/lunabee.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/lunabee.java-library-conventions.gradle.kts
@@ -25,12 +25,6 @@ plugins {
 
 group = AndroidConfig.GROUP_ID
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
-    kotlinOptions {
-        jvmTarget = AndroidConfig.JDK_VERSION.toString()
-    }
-}
-
 java {
     sourceCompatibility = AndroidConfig.JDK_VERSION
     targetCompatibility = AndroidConfig.JDK_VERSION

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,91 +2,37 @@
 
 [bundles]
 
-
-
 [plugins]
 
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 
+compose-plugin = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+
 [versions]
 
-kotlin = "1.9.23"
-##  ⬆ = "2.0.0-Beta1"
-##  ⬆ = "2.0.0-Beta2"
-##  ⬆ = "2.0.0-Beta3"
-##  ⬆ = "2.0.0-Beta4"
-##  ⬆ = "2.0.0-Beta5"
+kotlin = "2.0.0"
 
 android-gradle-plugin = "8.4.1"
-##                 ⬆ = "8.4.0-alpha01"
-##                 ⬆ = "8.4.0-alpha02"
-##                 ⬆ = "8.4.0-alpha03"
-##                 ⬆ = "8.4.0-alpha04"
-##                 ⬆ = "8.4.0-alpha05"
-##                 ⬆ = "8.4.0-alpha06"
-##                 ⬆ = "8.4.0-alpha07"
-##                 ⬆ = "8.4.0-alpha08"
-##                 ⬆ = "8.4.0-alpha09"
-##                 ⬆ = "8.4.0-alpha10"
-##                 ⬆ = "8.4.0-alpha11"
-##                 ⬆ = "8.4.0-alpha12"
-##                 ⬆ = "8.4.0-alpha13"
-##                 ⬆ = "8.4.0-beta01"
-##                 ⬆ = "8.4.0-beta02"
-##                 ⬆ = "8.5.0-alpha01"
-##                 ⬆ = "8.5.0-alpha02"
 
 detekt = "1.23.6"
 
 androidx-test-runner = "1.5.2"
-##                ⬆ = "1.5.3-alpha01"
-##                ⬆ = "1.6.0-alpha01"
-##                ⬆ = "1.6.0-alpha02"
-##                ⬆ = "1.6.0-alpha03"
-##                ⬆ = "1.6.0-alpha04"
-##                ⬆ = "1.6.0-alpha05"
-##                ⬆ = "1.6.0-alpha06"
 
-# Used to set kotlinCompilerExtensionVersion
-compose-compiler = "1.5.11"
-
-compose-bom = "2024.03.00"
+compose-bom = "2024.05.00"
 
 junit-junit = "4.13.2"
 
 android-tools-desugar_jdk_libs = "2.0.4"
 
-google-android-material = "1.11.0"
-##                   ⬆ = "1.12.0-alpha01"
-##                   ⬆ = "1.12.0-alpha02"
-##                   ⬆ = "1.12.0-alpha03"
-##                   ⬆ = "1.12.0-beta01"
+google-android-material = "1.12.0"
 
-androidx-appcompat = "1.6.1"
-##              ⬆ = "1.7.0-alpha01"
-##              ⬆ = "1.7.0-alpha02"
-##              ⬆ = "1.7.0-alpha03"
+androidx-appcompat = "1.7.0"
 
-androidx-core = "1.12.0"
-##         ⬆ = "1.13.0-alpha01"
-##         ⬆ = "1.13.0-alpha02"
-##         ⬆ = "1.13.0-alpha03"
-##         ⬆ = "1.13.0-alpha04"
-##         ⬆ = "1.13.0-alpha05"
-##         ⬆ = "1.13.0-beta01"
+androidx-core = "1.13.1"
 
-androidx-activity = "1.8.2"
-##             ⬆ = "1.9.0-alpha01"
-##             ⬆ = "1.9.0-alpha02"
-##             ⬆ = "1.9.0-alpha03"
-##             ⬆ = "1.9.0-beta01"
+androidx-activity = "1.9.0"
 
 androidx-navigation = "2.7.7"
-##               ⬆ = "2.8.0-alpha01"
-##               ⬆ = "2.8.0-alpha02"
-##               ⬆ = "2.8.0-alpha03"
-##               ⬆ = "2.8.0-alpha04"
-##               ⬆ = "2.8.0-alpha05"
 
 zoomable = "1.6.1"
 
@@ -100,10 +46,9 @@ desugarJdk = { group = "com.android.tools", name = "desugar_jdk_libs", version.r
 
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle-plugin" }
+compose-plugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 
-# Add compose compiler entry to get compiler updates
-compose-compiler = { group = "androidx.compose.compiler", name = "compiler", version.ref = "compose-compiler" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }


### PR DESCRIPTION
## 📜 Description

👉 Update to K2 and KSP2.
🆕 Replace Compose Compiler by Compose Plugin.
🆕 Replace `compilerOptions` usage:
```kotlin
// Before
tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
    kotlinOptions {
        jvmTarget = AndroidConfig.JDK_VERSION.toString()
    }
}

// After
kotlin.compilerOptions.jvmTarget.set(AndroidConfig.JVM_TARGET) // JvmTarget.JVM_17
```

👀 https://kotlinlang.org/docs/gradle-compiler-options.html#target-the-jvm

## 💡 Motivation and Context

👉 Start migrating our app to K2.

## 💚 How did you test it?

👉 Run the app and navigate in it.

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)
