### PR TITLE
Add logs

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -18,6 +18,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### LbcAndroidTest
 
 - Use `takeScreenshotNoSync` instead of `takeScreenshot` in case of test failure
+- Add `verbose` param to `LbcPrintRule` to enable verbose logging
 
 ## 2024-06-27
 

--- a/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/rule/LbcPrintRule.kt
+++ b/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/rule/LbcPrintRule.kt
@@ -29,6 +29,7 @@ class LbcPrintRule(
     private val usePublicStorage: Boolean,
     private val deleteOnSuccess: Boolean,
     private val appendTimestamp: Boolean = usePublicStorage,
+    private val verbose: Boolean,
 ) : TestWatcher() {
 
     companion object {
@@ -42,11 +43,13 @@ class LbcPrintRule(
             usePublicStorage: Boolean = false,
             deleteOnSuccess: Boolean = true,
             appendTimestamp: Boolean = usePublicStorage,
+            verbose: Boolean = true,
         ): LbcPrintRule = LbcPrintRule(
             appName = appName,
             usePublicStorage = usePublicStorage,
             deleteOnSuccess = deleteOnSuccess,
             appendTimestamp = appendTimestamp,
+            verbose = verbose,
         )
 
         /**
@@ -59,11 +62,13 @@ class LbcPrintRule(
             usePublicStorage: Boolean = true,
             deleteOnSuccess: Boolean = true,
             appendTimestamp: Boolean = usePublicStorage,
+            verbose: Boolean = true,
         ): LbcPrintRule = LbcPrintRule(
             appName = appName,
             usePublicStorage = usePublicStorage,
             deleteOnSuccess = deleteOnSuccess,
             appendTimestamp = appendTimestamp,
+            verbose = verbose,
         )
     }
 
@@ -102,9 +107,14 @@ class LbcPrintRule(
         } else {
             File(screenshotFolder, subFolder.toString())
         }
+
         val className = d.className.substringAfterLast(".")
         classFolder = File(appFolder, className)
         basePath = File(classFolder, d.methodName).absolutePath
+
+        if (verbose) {
+            Log.v("LbcPrintRule", "Screenshot test path: $basePath")
+        }
     }
 
     fun print(bitmap: Bitmap, suffix: String) {
@@ -115,6 +125,11 @@ class LbcPrintRule(
             screenFile.outputStream().use { outputStream ->
                 bitmap.compress(Bitmap.CompressFormat.JPEG, 50, outputStream)
             }
+
+            if (verbose) {
+                Log.v("LbcPrintRule", "Screenshot saved to ${screenFile.absolutePath}")
+            }
+
             screenshots += screenFile
         } finally {
             bitmap.recycle()
@@ -140,6 +155,9 @@ class LbcPrintRule(
     override fun succeeded(description: Description?) {
         super.succeeded(description)
         if (deleteOnSuccess) {
+            if (verbose) {
+                Log.v("LbcPrintRule", "Delete screenshots\n${screenshots.joinToString("\n") { "\t$it" }}")
+            }
             screenshots.forEach(File::delete)
             classFolder.delete() // try delete (fail if not empty)
             appFolder.delete() // try delete (fail if not empty)

--- a/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/rule/LbcPrintRule.kt
+++ b/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/rule/LbcPrintRule.kt
@@ -155,7 +155,7 @@ class LbcPrintRule(
     override fun succeeded(description: Description?) {
         super.succeeded(description)
         if (deleteOnSuccess) {
-            if (verbose) {
+            if (verbose && screenshots.isNotEmpty()) {
                 Log.v("LbcPrintRule", "Delete screenshots\n${screenshots.joinToString("\n") { "\t$it" }}")
             }
             screenshots.forEach(File::delete)


### PR DESCRIPTION
## 📜 Description
- Add param `verbose` to `LbcPrintRule` and show logs
  - On init
  - On each screenshot
  - On delete

## 💡 Motivation and Context
- Debug missing screenshots during some oneSafe tests

## 💚 How did you test it?
- Run `print_screenshot_on_timeout_test` and check logcat

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
<img width="1457" alt="image" src="https://github.com/user-attachments/assets/e9577b8e-5ae4-49b1-b026-21807f33cde9">
