### PR TITLE
Fix widget corner background

### DIFF
--- a/app/src/main/kotlin/studio/lunabee/compose/demo/glance/GlanceWidgetDemo.kt
+++ b/app/src/main/kotlin/studio/lunabee/compose/demo/glance/GlanceWidgetDemo.kt
@@ -49,8 +49,9 @@ import androidx.glance.layout.size
 import androidx.glance.text.TextAlign
 import studio.lunabee.compose.MainActivity
 import studio.lunabee.compose.R
-import studio.lunabee.compose.glance.extensions.appWidgetBackgroundCompat
+import studio.lunabee.compose.glance.extensions.cornerRadiusCompat
 import studio.lunabee.compose.glance.ui.GlanceBackground
+import studio.lunabee.compose.glance.ui.GlanceRoot
 import studio.lunabee.compose.glance.ui.GlanceTypefaceButton
 import studio.lunabee.compose.glance.ui.GlanceTypefaceText
 import studio.lunabee.compose.glance.ui.GlanceViewFlipper
@@ -69,73 +70,75 @@ class GlanceWidgetDemo : GlanceAppWidget() {
 
     @Composable
     fun Render() {
-        Column(
-            modifier = GlanceModifier
-                .appWidgetBackgroundCompat(
-                    cornerRadius = 16.dp,
-                    color = Color(0xFFE5DDC8),
-                    size = DpSize(LocalSize.current.width, LocalSize.current.height),
-                ),
-            horizontalAlignment = Alignment.Horizontal.CenterHorizontally,
-        ) {
-            Spacer(modifier = GlanceModifier.defaultWeight())
-
-            GlanceViewFlipper(
-                viewFlipperLayout = R.layout.glance_view_flipper,
-                viewFlipperViewId = R.id.glance_view_flipper,
-                flipInterval = 2.seconds,
+        GlanceRoot {
+            Column(
                 modifier = GlanceModifier
-                    .size(60.dp),
+                    .cornerRadiusCompat(
+                        cornerRadius = 16.dp,
+                        color = Color(0xFFE5DDC8),
+                        size = DpSize(LocalSize.current.width, LocalSize.current.height),
+                    ),
+                horizontalAlignment = Alignment.Horizontal.CenterHorizontally,
             ) {
-                listOf(
-                    R.drawable.ic_view_flipper_1,
-                    R.drawable.ic_view_flipper_2,
-                    R.drawable.ic_view_flipper_3,
-                    R.drawable.ic_view_flipper_4,
-                ).forEach { resId ->
-                    Image(
-                        provider = ImageProvider(resId = resId),
-                        contentDescription = null,
-                        modifier = GlanceModifier
-                            .size(size = 48.dp),
-                    )
+                Spacer(modifier = GlanceModifier.defaultWeight())
+
+                GlanceViewFlipper(
+                    viewFlipperLayout = R.layout.glance_view_flipper,
+                    viewFlipperViewId = R.id.glance_view_flipper,
+                    flipInterval = 2.seconds,
+                    modifier = GlanceModifier
+                        .size(60.dp),
+                ) {
+                    listOf(
+                        R.drawable.ic_view_flipper_1,
+                        R.drawable.ic_view_flipper_2,
+                        R.drawable.ic_view_flipper_3,
+                        R.drawable.ic_view_flipper_4,
+                    ).forEach { resId ->
+                        Image(
+                            provider = ImageProvider(resId = resId),
+                            contentDescription = null,
+                            modifier = GlanceModifier
+                                .size(size = 48.dp),
+                        )
+                    }
                 }
-            }
 
-            // The text will automatically fill the width and go to multiline if needed.
-            // You can specify a limited width with ellipsizedWidth (if you want to apply a padding for example).
-            GlanceTypefaceText(
-                text = "Welcome in this beautiful widget! Click on the button bellow to launch the application from here 😱!",
-                color = Color.Black,
-                fontSize = 14.sp,
-                typeface = ResourcesCompat.getFont(LocalContext.current, R.font.robot_regular)!!,
-                modifier = GlanceModifier
-                    .fillMaxWidth(),
-                textAlign = TextAlign.Center,
-            )
+                // The text will automatically fill the width and go to multiline if needed.
+                // You can specify a limited width with ellipsizedWidth (if you want to apply a padding for example).
+                GlanceTypefaceText(
+                    text = "Welcome in this beautiful widget! Click on the button bellow to launch the application from here 😱!",
+                    color = Color.Black,
+                    fontSize = 14.sp,
+                    typeface = ResourcesCompat.getFont(LocalContext.current, R.font.robot_regular)!!,
+                    modifier = GlanceModifier
+                        .fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                )
 
-            Spacer(modifier = GlanceModifier.height(8.dp))
+                Spacer(modifier = GlanceModifier.height(8.dp))
 
-            // Demonstration of a custom button with an XML background and a custom typeface. You can also use a classic
-            // Glance button if you don't have specific font or an ImageProvider/ColorProvider with the Modifier.
-            GlanceBackground(
-                background = R.drawable.widget_button_gradient_bg,
-                modifier = GlanceModifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-            ) {
-                GlanceTypefaceButton(
-                    text = "Open the app",
-                    color = Color.White,
-                    fontSize = 12.sp,
-                    typeface = ResourcesCompat.getFont(LocalContext.current, R.font.write)!!,
-                    action = actionStartActivity(MainActivity::class.java),
+                // Demonstration of a custom button with an XML background and a custom typeface. You can also use a classic
+                // Glance button if you don't have specific font or an ImageProvider/ColorProvider with the Modifier.
+                GlanceBackground(
+                    background = R.drawable.widget_button_gradient_bg,
                     modifier = GlanceModifier
                         .fillMaxWidth()
-                        .height(height = 48.dp),
-                )
+                        .padding(horizontal = 16.dp),
+                ) {
+                    GlanceTypefaceButton(
+                        text = "Open the app",
+                        color = Color.White,
+                        fontSize = 12.sp,
+                        typeface = ResourcesCompat.getFont(LocalContext.current, R.font.write)!!,
+                        action = actionStartActivity(MainActivity::class.java),
+                        modifier = GlanceModifier
+                            .fillMaxWidth()
+                            .height(height = 48.dp),
+                    )
+                }
+                Spacer(modifier = GlanceModifier.defaultWeight())
             }
-            Spacer(modifier = GlanceModifier.defaultWeight())
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,6 @@
 
 [bundles]
 
-
-
 [plugins]
 
 # Do not remove, use as "id" instead of alias, this is why it is not detected.
@@ -13,54 +11,21 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 [versions]
 
 androidx-activity = "1.9.2"
-##             ⬆ = "1.10.0-alpha01"
-##             ⬆ = "1.10.0-alpha02"
 androidx-appcompat = "1.7.0"
 androidx-core = "1.13.1"
-##         ⬆ = "1.14.0-alpha01"
-##         ⬆ = "1.15.0-alpha01"
-##         ⬆ = "1.15.0-alpha02"
 androidx-exifinterface = "1.3.7"
 androidx-glance = "1.1.0"
-android-gradle-plugin = "8.6.1"
-##                 ⬆ = "8.7.0-alpha01"
-##                 ⬆ = "8.7.0-alpha02"
-##                 ⬆ = "8.7.0-alpha03"
-##                 ⬆ = "8.7.0-alpha04"
-##                 ⬆ = "8.7.0-alpha05"
-##                 ⬆ = "8.7.0-alpha06"
-##                 ⬆ = "8.7.0-alpha07"
-##                 ⬆ = "8.7.0-alpha08"
-##                 ⬆ = "8.7.0-alpha09"
-##                 ⬆ = "8.7.0-beta01"
-##                 ⬆ = "8.7.0-beta02"
-##                 ⬆ = "8.7.0-rc01"
-##                 ⬆ = "8.8.0-alpha01"
-##                 ⬆ = "8.8.0-alpha02"
-##                 ⬆ = "8.8.0-alpha03"
-androidx-navigation = "2.8.1"
+android-gradle-plugin = "8.7.1"
+androidx-navigation = "2.8.2"
 androidx-test-runner = "1.6.2"
 android-tools-desugar_jdk_libs = "2.1.2"
 coil = "2.7.0"
-compose-bom = "2024.09.02"
+compose-bom = "2024.09.03"
 detekt = "1.23.7"
 google-android-material = "1.12.0"
-##                   ⬆ = "1.13.0-alpha01"
-##                   ⬆ = "1.13.0-alpha02"
-##                   ⬆ = "1.13.0-alpha03"
-##                   ⬆ = "1.13.0-alpha04"
-##                   ⬆ = "1.13.0-alpha05"
-##                   ⬆ = "1.13.0-alpha06"
 junit-junit = "4.13.2"
-kotlin = "2.0.20"
-##  ⬆ = "2.1.0-Beta1"
+kotlin = "2.0.21"
 zoomable = "1.6.2"
-##    ⬆ = "1.7.0-beta01"
-##    ⬆ = "1.7.0-beta02"
-##    ⬆ = "2.0.0-alpha01"
-##    ⬆ = "2.0.0-alpha02"
-##    ⬆ = "2.0.0-alpha03"
-##    ⬆ = "2.0.0-beta01"
 
 [libraries]
 

--- a/lbcglance/README.md
+++ b/lbcglance/README.md
@@ -21,9 +21,8 @@ Note that this demo app does not provide a configuration Activity. You can consu
 ### Extensions
 
 This package provides some extensions, as we have some limitation with Glance, i.e we can not use all Compose APIs (like LocalDensity, Modifier):
-- [DpExt.kt](src/main/kotlin/studio/lunabee/compose/glance/extensions/DpExt.kt): brings some extensions to create `Spacer` with a `GlanceModifier`
 - [GlanceModifierExt.kt](src/main/kotlin/studio/lunabee/compose/glance/extensions/GlanceModifierExt.kt):
-    - `appWidgetBackgroundCompat`: can be used to apply rounded corner on your widget on all APIs (supported by default only on API31+)
+    - `cornerRadiusCompat`: can be used to apply rounded corner on your widget on all APIs (supported by default only on API31+)
 - [GlanceDensityExt.kt](src/main/kotlin/studio/lunabee/compose/glance/extensions/GlanceDensityExt.kt): extension that replace usage of `LocalDensity.toPx`
 
 ### Helpers
@@ -35,6 +34,10 @@ This package provides helpful method or classes:
 - [PinWidgetToHomeScreenHelper.kt](src/main/kotlin/studio/lunabee/compose/glance/helpers/PinWidgetToHomeScreenHelper.kt): offers the possibility to pin the widget from the application (API26+)
 
 ### UI
+
+#### GlanceRoot
+
+With [GlanceRoot.kt](src/main/kotlin/studio/lunabee/compose/glance/ui/GlanceRoot.kt), you can automatically apply the `appWidgetBackground` Modifier
 
 #### GlanceBackground
 

--- a/lbcglance/src/main/kotlin/studio/lunabee/compose/glance/extensions/GlanceModifierExt.kt
+++ b/lbcglance/src/main/kotlin/studio/lunabee/compose/glance/extensions/GlanceModifierExt.kt
@@ -33,7 +33,6 @@ import androidx.core.graphics.drawable.toBitmap
 import androidx.glance.GlanceModifier
 import androidx.glance.ImageProvider
 import androidx.glance.LocalSize
-import androidx.glance.appwidget.appWidgetBackground
 import androidx.glance.appwidget.cornerRadius
 import androidx.glance.background
 import androidx.glance.layout.size
@@ -43,14 +42,15 @@ import kotlin.math.roundToInt
  * According to the documentation of [androidx.glance.appwidget.CornerRadiusModifier],
  * rounded corners are applied with [GlanceModifier.cornerRadius] method only on API S+ (31+).
  * For below APIs, we need to use a [ShapeDrawable] to keep our design consistency across APIs.
- * This methods also applied [appWidgetBackground], so don't use it again (otherwise, it will crash)!
+ * FIXME for Android S+, documentation advices to apply appWidgetBackground to the same view that handles corner radius.
+ *  -> But it is currently causing a flickering when the widget is moved by the user.
  * @param cornerRadius dimension in [Dp] of the desired corner radius. To keep your design consistency across all devices, it is mandatory,
  * as the default value used by Android on API31+ depends on the device. If you want to keep this behavior, you can use
  * [android.R.dimen.system_app_widget_background_radius] dimension.
  * @param color background color of your widget.
  * @param size size of your widget. Can be get with [LocalSize].
  */
-fun GlanceModifier.appWidgetBackgroundCompat(
+fun GlanceModifier.cornerRadiusCompat(
     cornerRadius: Dp,
     color: Color,
     size: DpSize,
@@ -67,5 +67,4 @@ fun GlanceModifier.appWidgetBackgroundCompat(
         size(width = size.width, height = size.height)
             .background(imageProvider = ImageProvider(bitmap = bitmap))
     }
-        .appWidgetBackground() // must be called only on the top view, will throw an exception if applied to multiple views.
 }

--- a/lbcglance/src/main/kotlin/studio/lunabee/compose/glance/ui/GlanceRoot.kt
+++ b/lbcglance/src/main/kotlin/studio/lunabee/compose/glance/ui/GlanceRoot.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 Lunabee Studio
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GlanceRoot.kt
+ * Lunabee Compose
+ *
+ * Created by Lunabee Studio / Date - 10/16/2024 - for the Lunabee Compose library.
+ */
+
+package studio.lunabee.compose.glance.ui
+
+import androidx.compose.runtime.Composable
+import androidx.glance.GlanceModifier
+import androidx.glance.appwidget.appWidgetBackground
+import androidx.glance.layout.Box
+
+/**
+ * Apply automatically [appWidgetBackground] to your widget.
+ */
+@Composable
+fun GlanceRoot(
+    modifier: GlanceModifier = GlanceModifier,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = GlanceModifier
+            .appWidgetBackground()
+            .then(other = modifier),
+        content = content,
+    )
+}


### PR DESCRIPTION
## 📜 Description

👉 On Android S+, when user moves the widget, corner radius disappear.
🌵 `appWidgetBackground` should not be applied on the view that has the corner radius (Google's issue).
✅ Solution: GlanceRoot to apply `appWidgetBackground` and apply corner radius in inner view.
ℹ️ The documentation advices the opposite but it is not working. I will create an issue on the tracker.

## 💡 Motivation and Context

👉 Fix backport from `amo` 🤫 might be useful for Gysc.

## 💚 How did you test it?

👉 Run on Android 15 and move the widget.
👉 Same on Galaxy S8

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [ ] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)