### PR TITLE
Fix focus on API 27

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -44,6 +44,7 @@
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="LINE_BREAK_AFTER_MULTILINE_WHEN_ENTRY" value="false" />
+      <option name="INDENT_BEFORE_ARROW_ON_NEW_LINE" value="false" />
       <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="true" />
       <option name="CONTINUATION_INDENT_IN_ARGUMENT_LISTS" value="true" />
       <option name="CONTINUATION_INDENT_FOR_EXPRESSION_BODIES" value="true" />
@@ -53,6 +54,7 @@
       <option name="CONTINUATION_INDENT_IN_ELVIS" value="true" />
       <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="0" />
       <option name="IF_RPAREN_ON_NEW_LINE" value="false" />
+      <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <XML>

--- a/.idea/inspectionProfiles/Lunabee.xml
+++ b/.idea/inspectionProfiles/Lunabee.xml
@@ -1,21 +1,46 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Lunabee" />
-    <inspection_tool class="AndroidLintConvertToWebp" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="AndroidLintIconExpectedSize" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AndroidLintNegativeMargin" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AndroidLintNewerVersionAvailable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AndroidLintSelectableText" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AndroidLintTypographyQuotes" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="AndroidLintVisibleForTests" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="AndroidLintConvertToWebp" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintIconExpectedSize" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintNegativeMargin" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintNewerVersionAvailable" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintSelectableText" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintTypographyQuotes" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AndroidLintVisibleForTests" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CanSealedSubClassBeObject" enabled="true" level="INFO" enabled_by_default="true" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="ConstantConditions" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="true" />
       <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
     </inspection_tool>
     <inspection_tool class="ConstantValueMerged" />
     <inspection_tool class="Destructure" enabled="true" level="INFORMATION" enabled_by_default="true" />
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="MoveVariableDeclarationIntoWhen" enabled="true" level="INFORMATION" enabled_by_default="true" />
+    <inspection_tool class="OptionalOfNullableMisuseMerged" />
     <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
@@ -23,6 +48,9 @@
     <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -4,6 +4,6 @@
     <option name="jvmTarget" value="17" />
   </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.20" />
+    <option name="version" value="2.0.21" />
   </component>
 </project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -5,8 +5,12 @@
       <set>
         <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
         <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
         <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
         <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
       </set>
     </option>
   </component>

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,10 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### LbcUiField
+
+#### Fixed
+
+- Focus issue when using a time field as first field depending on Android API version (reproducible on API 27)
 
 ### LbcAccessibility
 

--- a/app/src/main/kotlin/studio/lunabee/compose/demo/uifield/UiFieldsScreen.kt
+++ b/app/src/main/kotlin/studio/lunabee/compose/demo/uifield/UiFieldsScreen.kt
@@ -85,8 +85,8 @@ fun UiFieldsScreen(
             initialValue = "",
             placeholder = LbcTextSpec.Raw("This is a password Text Field"),
             label = LbcTextSpec.Raw("Password"),
-            isFieldInError = {
-                null
+            isFieldInError = { value ->
+                if (value.length < 6) UiFieldError(LbcTextSpec.Raw("At least 6 chars required")) else null
             },
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Next,
@@ -168,9 +168,9 @@ fun UiFieldsScreen(
             .padding(all = 16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
+        dateAndHourUiField.Composable(modifier = Modifier.fillMaxWidth())
         normalUiTextField.Composable(modifier = Modifier.fillMaxWidth())
         passwordUiTextField.Composable(modifier = Modifier.fillMaxWidth())
-        dateAndHourUiField.Composable(modifier = Modifier.fillMaxWidth())
         dateUiField.Composable(modifier = Modifier.fillMaxWidth())
 
         Button(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,8 @@
 
 [bundles]
 
+
+
 [plugins]
 
 # Do not remove, use as "id" instead of alias, this is why it is not detected.
@@ -10,22 +12,50 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 
 [versions]
 
-androidx-activity = "1.9.2"
+androidx-activity = "1.9.3"
+##             ⬆ = "1.10.0-alpha01"
+##             ⬆ = "1.10.0-alpha02"
+##             ⬆ = "1.10.0-alpha03"
 androidx-appcompat = "1.7.0"
-androidx-core = "1.13.1"
+androidx-core = "1.15.0"
 androidx-exifinterface = "1.3.7"
-androidx-glance = "1.1.0"
+androidx-glance = "1.1.1"
 android-gradle-plugin = "8.7.1"
-androidx-navigation = "2.8.2"
+##                 ⬆ = "8.8.0-alpha01"
+##                 ⬆ = "8.8.0-alpha02"
+##                 ⬆ = "8.8.0-alpha03"
+##                 ⬆ = "8.8.0-alpha04"
+##                 ⬆ = "8.8.0-alpha05"
+##                 ⬆ = "8.8.0-alpha06"
+##                 ⬆ = "8.8.0-alpha07"
+##                 ⬆ = "8.8.0-alpha08"
+androidx-navigation = "2.8.3"
+##               ⬆ = "2.9.0-alpha01"
+##               ⬆ = "2.9.0-alpha02"
 androidx-test-runner = "1.6.2"
 android-tools-desugar_jdk_libs = "2.1.2"
 coil = "2.7.0"
-compose-bom = "2024.09.03"
+compose-bom = "2024.10.01"
 detekt = "1.23.7"
 google-android-material = "1.12.0"
+##                   ⬆ = "1.13.0-alpha01"
+##                   ⬆ = "1.13.0-alpha02"
+##                   ⬆ = "1.13.0-alpha03"
+##                   ⬆ = "1.13.0-alpha04"
+##                   ⬆ = "1.13.0-alpha05"
+##                   ⬆ = "1.13.0-alpha06"
+##                   ⬆ = "1.13.0-alpha07"
 junit-junit = "4.13.2"
 kotlin = "2.0.21"
+##  ⬆ = "2.1.0-Beta1"
+##  ⬆ = "2.1.0-Beta2"
 zoomable = "1.6.2"
+##    ⬆ = "1.7.0-beta01"
+##    ⬆ = "1.7.0-beta02"
+##    ⬆ = "2.0.0-alpha01"
+##    ⬆ = "2.0.0-alpha02"
+##    ⬆ = "2.0.0-alpha03"
+##    ⬆ = "2.0.0-beta01"
 
 [libraries]
 

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/UiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/UiField.kt
@@ -52,7 +52,10 @@ abstract class UiField<T> {
 
     protected val error: MutableStateFlow<UiFieldError?> = MutableStateFlow(null)
 
-    protected var hasBeenCaptured: Boolean = false
+    /**
+     * Focus has been acquired by the field at least once
+     */
+    protected var hasBeenFocused: Boolean = false
 
     var value: T
         get() = mValue.value
@@ -68,7 +71,7 @@ abstract class UiField<T> {
         return error != null
     }
 
-    fun dismissDismissedError() {
+    fun dismissError() {
         error.value = null
     }
 

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/UiFieldStyleData.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/UiFieldStyleData.kt
@@ -21,6 +21,7 @@
 
 package studio.lunabee.compose.foundation.uifield.field.style
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -45,5 +46,6 @@ interface UiFieldStyleData {
         maxLine: Int,
         readOnly: Boolean,
         error: UiFieldError?,
+        interactionSource: MutableInteractionSource? = null,
     )
 }

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/UiFieldStyleDataImpl.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/UiFieldStyleDataImpl.kt
@@ -22,6 +22,7 @@
 package studio.lunabee.compose.foundation.uifield.field.style
 
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.text.KeyboardActions
@@ -49,6 +50,7 @@ class UiFieldStyleDataImpl : UiFieldStyleData {
         maxLine: Int,
         readOnly: Boolean,
         error: UiFieldError?,
+        interactionSource: MutableInteractionSource?,
     ) {
         OutlinedTextField(
             value = value,
@@ -68,6 +70,7 @@ class UiFieldStyleDataImpl : UiFieldStyleData {
             },
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
+            interactionSource = interactionSource,
         )
     }
 }

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/TextUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/TextUiField.kt
@@ -47,22 +47,22 @@ abstract class TextUiField : UiField<String>() {
             value = valueToDisplayedString(collectedValue),
             onValueChange = { value = it },
             modifier = modifier.onFocusEvent {
-                if (!it.hasFocus && hasBeenCaptured) {
+                if (!it.hasFocus && hasBeenFocused) {
                     checkAndDisplayError()
                 } else {
-                    hasBeenCaptured = true
-                    dismissDismissedError()
+                    hasBeenFocused = true
+                    dismissError()
                 }
             },
             placeholder = placeholder,
+            label = label,
             trailingIcon = { options.forEach { it.Composable(modifier = Modifier) } },
             visualTransformation = collectedVisualTransformation,
-            maxLine = maxLine,
-            readOnly = false,
-            label = label,
-            error = collectedError,
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
+            maxLine = maxLine,
+            readOnly = false,
+            error = collectedError,
         )
     }
 

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/TimeUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/TimeUiField.kt
@@ -43,13 +43,18 @@ abstract class TimeUiField<T> : UiField<T>() {
         val collectedValue by mValue.collectAsState()
         val collectedError by error.collectAsState()
         // https://stackoverflow.com/a/70335041
-        val interactionSource = remember { MutableInteractionSource() }
-        LaunchedEffect(interactionSource) {
-            interactionSource.interactions.collect { interaction ->
-                if (interaction is PressInteraction.Release) {
-                    options.firstOrNull()?.onClick()
+        val interactionSource = if (options.isNotEmpty()) {
+            remember { MutableInteractionSource() }.also { interactionSource ->
+                LaunchedEffect(interactionSource) {
+                    interactionSource.interactions.collect { interaction ->
+                        if (interaction is PressInteraction.Release) {
+                            options.firstOrNull()?.onClick()
+                        }
+                    }
                 }
             }
+        } else {
+            null
         }
         uiFieldStyleData.ComposeTextField(
             value = valueToDisplayedString(collectedValue),

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/TimeUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/TimeUiField.kt
@@ -21,12 +21,16 @@
 
 package studio.lunabee.compose.foundation.uifield.field.time
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.text.input.VisualTransformation
@@ -38,6 +42,15 @@ abstract class TimeUiField<T> : UiField<T>() {
     override fun Composable(modifier: Modifier) {
         val collectedValue by mValue.collectAsState()
         val collectedError by error.collectAsState()
+        // https://stackoverflow.com/a/70335041
+        val interactionSource = remember { MutableInteractionSource() }
+        LaunchedEffect(interactionSource) {
+            interactionSource.interactions.collect { interaction ->
+                if (interaction is PressInteraction.Release) {
+                    options.firstOrNull()?.onClick()
+                }
+            }
+        }
         uiFieldStyleData.ComposeTextField(
             value = valueToDisplayedString(collectedValue),
             onValueChange = {},
@@ -45,22 +58,20 @@ abstract class TimeUiField<T> : UiField<T>() {
                 .fillMaxWidth()
                 .onFocusEvent {
                     if (it.hasFocus) {
-                        dismissDismissedError()
-                        hasBeenCaptured = true
-                        options
-                            .first()
-                            .onClick()
+                        dismissError()
+                        hasBeenFocused = true
                     }
                 },
             placeholder = placeholder,
+            label = label,
             trailingIcon = { options.forEach { it.Composable(modifier = Modifier) } },
             visualTransformation = VisualTransformation.None,
+            keyboardOptions = KeyboardOptions.Default,
+            keyboardActions = KeyboardActions.Default,
             maxLine = 1,
             readOnly = true,
-            label = label,
             error = collectedError,
-            keyboardActions = KeyboardActions.Default,
-            keyboardOptions = KeyboardOptions.Default,
+            interactionSource = interactionSource,
         )
     }
 }

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/date/DatePickerOption.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/date/DatePickerOption.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalFocusManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import studio.lunabee.compose.core.LbcTextSpec
 import studio.lunabee.compose.foundation.uifield.UiFieldOption
@@ -46,7 +45,6 @@ class DatePickerOption : UiFieldOption {
     @Composable
     override fun Composable(modifier: Modifier) {
         val collectedIsPickedVisible by isPickerVisible.collectAsState()
-        val focusManager = LocalFocusManager.current
         TrailingAction(
             image = datePickerData.icon,
             onClick = { isPickerVisible.value = true },
@@ -54,7 +52,6 @@ class DatePickerOption : UiFieldOption {
             modifier = modifier,
         )
         if (collectedIsPickedVisible) {
-            focusManager.clearFocus(true)
             UiFieldDatePicker(
                 date = date,
                 onDismiss = { isPickerVisible.value = false },

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/hour/HourPickerOption.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/hour/HourPickerOption.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalFocusManager
 import kotlinx.coroutines.flow.MutableStateFlow
 import studio.lunabee.compose.core.LbcTextSpec
 import studio.lunabee.compose.foundation.uifield.UiFieldOption
@@ -44,7 +43,6 @@ class HourPickerOption : UiFieldOption {
     @Composable
     override fun Composable(modifier: Modifier) {
         val collectedIsPickedVisible by isPickerVisible.collectAsState()
-        val focusManager = LocalFocusManager.current
         TrailingAction(
             image = hourPickerData.icon,
             onClick = { isPickerVisible.value = true },
@@ -52,7 +50,6 @@ class HourPickerOption : UiFieldOption {
             modifier = modifier,
         )
         if (collectedIsPickedVisible) {
-            focusManager.clearFocus(true)
             UiFieldTimePicker(
                 onDismiss = { isPickerVisible.value = false },
                 hour = dateTime?.hour ?: 0,


### PR DESCRIPTION
## 📜 Description
- Don't clear focus to avoid another component to be unexpectedly focus
- Use interactionSource instead of focus listener to trigger option's onClick when clicking on a read only field (time field)
  - It allows to trigger the date picker even if the field is focused

## 💡 Motivation and Context
- Before ->

[bug_date_field.webm](https://github.com/user-attachments/assets/1a17db81-2f4e-44bc-a279-047239a1cdd1)


https://github.com/user-attachments/assets/9a108215-845b-43fd-8369-7fc7e3efdec1



## 💚 How did you test it?
- Play with uifield demo on API 34 & 27

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
