### PR TITLE
feature/fix_abstract_compose

### DIFF
--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/UiFieldStyleData.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/UiFieldStyleData.kt
@@ -46,6 +46,6 @@ interface UiFieldStyleData {
         maxLine: Int,
         readOnly: Boolean,
         error: UiFieldError?,
-        interactionSource: MutableInteractionSource? = null,
+        interactionSource: MutableInteractionSource?,
     )
 }

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/TextUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/TextUiField.kt
@@ -63,6 +63,7 @@ abstract class TextUiField : UiField<String>() {
             maxLine = maxLine,
             readOnly = false,
             error = collectedError,
+            interactionSource = null,
         )
     }
 


### PR DESCRIPTION
## 📜 Description
- Remove default value of `interactionSource` which seems to cause [AbstractMethodError](https://docs.oracle.com/javase/7/docs/api/java/lang/AbstractMethodError.html) on client app

## 💡 Motivation and Context
- Fix param added in #85 

## 💚 How did you test it?
- Local publish on RunMotion

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [ ] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
