### PR TITLE
Expose readOnly & enabled for LBUiField

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,10 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres  
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## 2025-02-18
+
+### LbcUiField
+- Expose `enable` and `readOnly` field
 
 ## 2025-02-12
 
@@ -29,7 +34,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### LbcUiField
 
-- **Breaking**: Add an `interactionSource` param to `ComposeTextField` to fix a focus issue when using a time field as first field depending
+- **Breaking**: Add an `interactionSource` param to `ComposeTextField` to fix a focus issue when using a time field as first field depending  
   on Android API version (reproducible on API 27)
 
 ### LbcAccessibility
@@ -52,17 +57,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 2024-06-27
 
-```
-lbcCore = "1.4.0"
-lbcFoundation = "1.3.0"
-lbcAndroidTest = "1.2.0"
-lbcAccessibility = "1.7.0"
-lbcTheme = "1.3.0"
-matieralColorUtilities = "1.2.0"
-lbcHaptic = "1.1.0"
-lbcUiField = "1.0.1"
-lbcImage = "1.0.1"
-```
+```  
+lbcCore = "1.4.0"  
+lbcFoundation = "1.3.0"  
+lbcAndroidTest = "1.2.0"  
+lbcAccessibility = "1.7.0"  
+lbcTheme = "1.3.0"  
+matieralColorUtilities = "1.2.0"  
+lbcHaptic = "1.1.0"  
+lbcUiField = "1.0.1"  
+lbcImage = "1.0.1"  
+```  
 
 ### LbcImage
 
@@ -87,31 +92,31 @@ lbcImage = "1.0.1"
 - `LbcCore`: Add `fun annotated(context: Context): AnnotatedString` in `LbcTextSpec` to retrieve `AnnotatedString` directly
 - `LbcCore`: Add `LbcImageSpec`
 
-```
-lbcCore = "1.4.0"
-lbcFoundation = "1.3.0"
-lbcAndroidTest = "1.2.0"
-lbcAccessibility = "1.7.0"
-lbcTheme = "1.3.0"
-matieralColorUtilities = "1.2.0"
-lbcHaptic = "1.1.0"
-lbcUiField = "1.0.0"
-lbcImage = "1.0.0"
-```
+```  
+lbcCore = "1.4.0"  
+lbcFoundation = "1.3.0"  
+lbcAndroidTest = "1.2.0"  
+lbcAccessibility = "1.7.0"  
+lbcTheme = "1.3.0"  
+matieralColorUtilities = "1.2.0"  
+lbcHaptic = "1.1.0"  
+lbcUiField = "1.0.0"  
+lbcImage = "1.0.0"  
+```  
 
 ## 2024-03-28
 
-```
-lbcCore 1.3.0
-lbcFoundation 1.2.0
-lbcAndroidTest 1.3.0
-lbcAccessibility 1.6.0
-lbcTheme 1.2.0
-materialColorUtilities 1.2.0
-lbcHaptic 1.0.0
-lbcImage 1.0.0
-lbcUiField 1.0.0
-```
+```  
+lbcCore 1.3.0  
+lbcFoundation 1.2.0  
+lbcAndroidTest 1.3.0  
+lbcAccessibility 1.6.0  
+lbcTheme 1.2.0  
+materialColorUtilities 1.2.0  
+lbcHaptic 1.0.0  
+lbcImage 1.0.0  
+lbcUiField 1.0.0  
+```  
 
 ## 1.2.0
 
@@ -216,7 +221,7 @@ lbcUiField 1.0.0
 
 #### Added
 
-- Update Jetpack Compose to `1.2.0`  and Kotlin to `1.7.0`
+- Update Jetpack Compose to `1.2.0` and Kotlin to `1.7.0`
 
 ## 1.2.0
 

--- a/app/src/main/kotlin/studio/lunabee/compose/demo/uifield/UiFieldsScreen.kt
+++ b/app/src/main/kotlin/studio/lunabee/compose/demo/uifield/UiFieldsScreen.kt
@@ -78,6 +78,7 @@ fun UiFieldsScreen(
             ),
             savedStateHandle = savedStateHandle,
             id = "1",
+            readOnly = true,
         )
     }
     val passwordUiTextField = remember {
@@ -152,6 +153,41 @@ fun UiFieldsScreen(
             ),
         )
     }
+
+    val readOnlyField = remember {
+        NormalUiTextField(
+            initialValue = "Read only field",
+            placeholder = LbcTextSpec.Raw(""),
+            label = LbcTextSpec.Raw("Read only"),
+            isFieldInError = { value ->
+                if (value.isBlank()) UiFieldError(LbcTextSpec.Raw("Should not be null")) else null
+            },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next,
+            ),
+            savedStateHandle = savedStateHandle,
+            id = "5",
+            readOnly = true,
+        )
+    }
+
+    val disabledField = remember {
+        NormalUiTextField(
+            initialValue = "Disabled field",
+            placeholder = LbcTextSpec.Raw(""),
+            label = LbcTextSpec.Raw("Disabled"),
+            isFieldInError = { value ->
+                if (value.isBlank()) UiFieldError(LbcTextSpec.Raw("Should not be null")) else null
+            },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next,
+            ),
+            savedStateHandle = savedStateHandle,
+            id = "6",
+            readOnly = true,
+            enabled = false,
+        )
+    }
     val areFieldsInError by combine(
         normalUiTextField.isInError,
         passwordUiTextField.isInError,
@@ -172,6 +208,8 @@ fun UiFieldsScreen(
         normalUiTextField.Composable(modifier = Modifier.fillMaxWidth())
         passwordUiTextField.Composable(modifier = Modifier.fillMaxWidth())
         dateUiField.Composable(modifier = Modifier.fillMaxWidth())
+        readOnlyField.Composable(modifier = Modifier.fillMaxWidth())
+        disabledField.Composable(modifier = Modifier.fillMaxWidth())
 
         Button(
             onClick = {

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -42,7 +42,7 @@ object AndroidConfig {
     const val LBCTHEME_VERSION: String = "1.7.0"
     const val MATERIAL_COLOR_UTILITIES_VERSION: String = "1.7.0"
     const val LBCHAPTIC_VERSION: String = "1.5.0"
-    const val LBCUIFIELD_VERSION: String = "1.5.0"
+    const val LBCUIFIELD_VERSION: String = "1.6.0"
     const val LBCIMAGE_VERSION: String = "1.4.0"
     const val LBCGLANCE_VERSION: String = "1.3.0"
     const val LBCPRESENTER_VERSION: String = "1.2.0"

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/UiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/UiField.kt
@@ -41,6 +41,8 @@ abstract class UiField<T> {
     abstract val uiFieldStyleData: UiFieldStyleData
     abstract val isFieldInError: (T) -> UiFieldError?
     abstract val onValueChange: (T) -> Unit
+    abstract val readOnly: Boolean
+    abstract val enabled: Boolean
 
     protected val mValue: MutableStateFlow<T> by lazy {
         MutableStateFlow(

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/PasswordUiFieldData.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/PasswordUiFieldData.kt
@@ -37,7 +37,9 @@ interface PasswordUiFieldData {
         modifier: Modifier,
         placeholder: LbcTextSpec,
         label: LbcTextSpec,
-        trailingIcon: @Composable() (() -> Unit)?,
+        trailingIcon:
+        @Composable()
+        (() -> Unit)?,
         isValueVisible: Boolean,
         keyboardOptions: KeyboardOptions,
         onKeyboardActions: KeyboardActionHandler,

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/PasswordUiFieldDataImpl.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/PasswordUiFieldDataImpl.kt
@@ -50,7 +50,9 @@ class PasswordUiFieldDataImpl : PasswordUiFieldData {
         modifier: Modifier,
         placeholder: LbcTextSpec,
         label: LbcTextSpec,
-        trailingIcon: @Composable() (() -> Unit)?,
+        trailingIcon:
+        @Composable()
+        (() -> Unit)?,
         isValueVisible: Boolean,
         keyboardOptions: KeyboardOptions,
         onKeyboardActions: KeyboardActionHandler,

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/UiFieldStyleData.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/UiFieldStyleData.kt
@@ -44,6 +44,7 @@ interface UiFieldStyleData {
         keyboardActions: KeyboardActions,
         maxLine: Int,
         readOnly: Boolean,
+        enabled: Boolean,
         error: UiFieldError?,
         interactionSource: MutableInteractionSource?,
     )

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/UiFieldStyleDataImpl.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/style/UiFieldStyleDataImpl.kt
@@ -48,6 +48,7 @@ class UiFieldStyleDataImpl : UiFieldStyleData {
         keyboardActions: KeyboardActions,
         maxLine: Int,
         readOnly: Boolean,
+        enabled: Boolean,
         error: UiFieldError?,
         interactionSource: MutableInteractionSource?,
     ) {
@@ -60,6 +61,7 @@ class UiFieldStyleDataImpl : UiFieldStyleData {
             label = { Text(text = label.string) },
             maxLines = maxLine,
             readOnly = readOnly,
+            enabled = enabled,
             visualTransformation = visualTransformation,
             isError = error != null,
             supportingText = if (error?.text != null) {

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/NormalUiTextField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/NormalUiTextField.kt
@@ -46,6 +46,8 @@ class NormalUiTextField(
     override val keyboardActions: KeyboardActions = KeyboardActions.Default,
     override val uiFieldStyleData: UiFieldStyleData = UiFieldStyleDataImpl(),
     override val maxLine: Int = 1,
+    override val readOnly: Boolean = false,
+    override val enabled: Boolean = true,
     override val visualTransformation: StateFlow<VisualTransformation> = MutableStateFlow(
         VisualTransformation.None,
     ).asStateFlow(),

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/PasswordUiTextField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/PasswordUiTextField.kt
@@ -54,6 +54,8 @@ class PasswordUiTextField(
     override val savedStateHandle: SavedStateHandle,
     private val passwordUiFieldData: PasswordUiFieldData = PasswordUiFieldDataImpl(),
     override val onValueChange: (String) -> Unit = {},
+    override val readOnly: Boolean = false,
+    override val enabled: Boolean = true,
     private val maxLine: Int = 1,
     private val keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     private val onKeyboardActions: KeyboardActionHandler = KeyboardActionHandler { /* no-op */ },

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/TextUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/TextUiField.kt
@@ -68,7 +68,8 @@ abstract class TextUiField : UiField<String>() {
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
             maxLine = maxLine,
-            readOnly = false,
+            readOnly = readOnly,
+            enabled = enabled,
             error = collectedError,
             interactionSource = null,
         )

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateAndHourUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateAndHourUiField.kt
@@ -58,6 +58,8 @@ class DateAndHourUiField(
         .ofLocalizedDateTime(FormatStyle.SHORT)
         .withZone(ZoneOffset.UTC),
     override val onValueChange: (LocalDateTime?) -> Unit = {},
+    override val readOnly: Boolean = false,
+    override val enabled: Boolean = true,
 ) : TimeUiField<LocalDateTime?>(), HourPickerHolder, DatePickerHolder {
     override val options: List<UiFieldOption> = listOf(
         DatePickerOption(),

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateUiField.kt
@@ -53,6 +53,8 @@ class DateUiField(
         .ofLocalizedDate(FormatStyle.SHORT)
         .withZone(ZoneOffset.UTC),
     override val onValueChange: (LocalDate?) -> Unit = {},
+    override val readOnly: Boolean = false,
+    override val enabled: Boolean = true,
 ) : TimeUiField<LocalDate?>(), DatePickerHolder {
     override val options: List<UiFieldOption> = listOf(DatePickerOption())
     override fun savedValueToData(value: String): LocalDate {

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/TimeUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/TimeUiField.kt
@@ -78,7 +78,8 @@ abstract class TimeUiField<T> : UiField<T>() {
             keyboardOptions = KeyboardOptions.Default,
             keyboardActions = KeyboardActions.Default,
             maxLine = 1,
-            readOnly = true,
+            readOnly = readOnly,
+            enabled = enabled,
             error = collectedError,
             interactionSource = interactionSource,
         )


### PR DESCRIPTION
## 📜 Description

Expose readOnly & enabled for UiField


## 💡 Motivation and Context

## 💚 How did you test it?
- Check the last 2 fields of UiFieldScreen (readOnly and disabled)

## 📝 Checklist
* [ ] I reviewed the submitted code
* [ ] I launched `./gradlew detekt`
* [ ] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs

<img src="https://github.com/user-attachments/assets/ea94a626-e72c-4b7a-8741-9aef63f9e4ec" width=300px /> 
