### PR TITLE
📆 Disable hour and date dialog if field is disabled

### DIFF
--- a/app/src/main/kotlin/studio/lunabee/compose/demo/uifield/UiFieldsScreen.kt
+++ b/app/src/main/kotlin/studio/lunabee/compose/demo/uifield/UiFieldsScreen.kt
@@ -58,6 +58,7 @@ import studio.lunabee.compose.foundation.uifield.field.time.DateUiField
 import studio.lunabee.compose.foundation.uifield.field.time.option.date.DatePickerData
 import studio.lunabee.compose.foundation.uifield.field.time.option.hour.HourPickerData
 import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -188,6 +189,32 @@ fun UiFieldsScreen(
             enabled = false,
         )
     }
+
+    val disabledDateUiField = remember {
+        DateUiField(
+            initialValue = LocalDate.now(),
+            placeholder = LbcTextSpec.Raw(""),
+            enabled = false,
+            label = LbcTextSpec.Raw("Disabled date uifield"),
+            isFieldInError = {
+                null
+            },
+            selectableDates = object : SelectableDates {
+                override fun isSelectableDate(utcTimeMillis: Long): Boolean {
+                    return Instant.now().toEpochMilli() < utcTimeMillis
+                }
+            },
+            savedStateHandle = savedStateHandle,
+            id = "7",
+            datePickerData = DatePickerData(
+                datePickerClickLabel = LbcTextSpec.Raw("Picker Date"),
+                datePickerConfirmLabel = LbcTextSpec.Raw("Confirm"),
+                datePickerCancelLabel = LbcTextSpec.Raw("Cancel"),
+                icon = LbcImageSpec.KtImageVector(Icons.Default.DateRange),
+            ),
+        )
+    }
+
     val areFieldsInError by combine(
         normalUiTextField.isInError,
         passwordUiTextField.isInError,
@@ -210,6 +237,7 @@ fun UiFieldsScreen(
         dateUiField.Composable(modifier = Modifier.fillMaxWidth())
         readOnlyField.Composable(modifier = Modifier.fillMaxWidth())
         disabledField.Composable(modifier = Modifier.fillMaxWidth())
+        disabledDateUiField.Composable(modifier = Modifier.fillMaxWidth())
 
         Button(
             onClick = {

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -42,7 +42,7 @@ object AndroidConfig {
     const val LBCTHEME_VERSION: String = "1.7.0"
     const val MATERIAL_COLOR_UTILITIES_VERSION: String = "1.7.0"
     const val LBCHAPTIC_VERSION: String = "1.5.0"
-    const val LBCUIFIELD_VERSION: String = "1.6.2"
+    const val LBCUIFIELD_VERSION: String = "1.6.3"
     const val LBCIMAGE_VERSION: String = "1.4.0"
     const val LBCGLANCE_VERSION: String = "1.3.0"
     const val LBCPRESENTER_VERSION: String = "1.4.0"

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateAndHourUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateAndHourUiField.kt
@@ -62,8 +62,8 @@ class DateAndHourUiField(
     override val enabled: Boolean = true,
 ) : TimeUiField<LocalDateTime?>(), HourPickerHolder, DatePickerHolder {
     override val options: List<UiFieldOption> = listOf(
-        DatePickerOption(),
-        HourPickerOption(),
+        DatePickerOption(enabled && !readOnly),
+        HourPickerOption(enabled && !readOnly),
     )
 
     override fun savedValueToData(value: String): LocalDateTime {

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateUiField.kt
@@ -56,7 +56,7 @@ class DateUiField(
     override val readOnly: Boolean = false,
     override val enabled: Boolean = true,
 ) : TimeUiField<LocalDate?>(), DatePickerHolder {
-    override val options: List<UiFieldOption> = listOf(DatePickerOption())
+    override val options: List<UiFieldOption> = listOf(DatePickerOption(enabled && !readOnly))
     override fun savedValueToData(value: String): LocalDate {
         return LocalDate.parse(value)
     }

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/TimeUiField.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/TimeUiField.kt
@@ -43,7 +43,7 @@ abstract class TimeUiField<T> : UiField<T>() {
         val collectedValue by mValue.collectAsState()
         val collectedError by error.collectAsState()
         // https://stackoverflow.com/a/70335041
-        val interactionSource = if (options.isNotEmpty()) {
+        val interactionSource = if (options.isNotEmpty() && enabled && !readOnly) {
             remember { MutableInteractionSource() }.also { interactionSource ->
                 LaunchedEffect(interactionSource) {
                     interactionSource.interactions.collect { interaction ->

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/date/DatePickerOption.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/date/DatePickerOption.kt
@@ -32,7 +32,9 @@ import studio.lunabee.compose.foundation.uifield.UiFieldOption
 import studio.lunabee.compose.foundation.uifield.composable.TrailingAction
 
 context(DatePickerHolder)
-class DatePickerOption : UiFieldOption {
+class DatePickerOption(
+    private val enabled: Boolean,
+) : UiFieldOption {
     private val isPickerVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override val clickLabel: LbcTextSpec = datePickerData.datePickerClickLabel
@@ -45,12 +47,14 @@ class DatePickerOption : UiFieldOption {
     @Composable
     override fun Composable(modifier: Modifier) {
         val collectedIsPickedVisible by isPickerVisible.collectAsState()
-        TrailingAction(
-            image = datePickerData.icon,
-            onClick = { isPickerVisible.value = true },
-            contentDescription = null,
-            modifier = modifier,
-        )
+        if (enabled) {
+            TrailingAction(
+                image = datePickerData.icon,
+                onClick = { isPickerVisible.value = true },
+                contentDescription = null,
+                modifier = modifier,
+            )
+        }
         if (collectedIsPickedVisible) {
             UiFieldDatePicker(
                 date = date,

--- a/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/hour/HourPickerOption.kt
+++ b/lbcuifield/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/hour/HourPickerOption.kt
@@ -31,7 +31,7 @@ import studio.lunabee.compose.foundation.uifield.UiFieldOption
 import studio.lunabee.compose.foundation.uifield.composable.TrailingAction
 
 context(HourPickerHolder)
-class HourPickerOption : UiFieldOption {
+class HourPickerOption(private val enabled: Boolean) : UiFieldOption {
     private val isPickerVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override val clickLabel: LbcTextSpec = hourPickerData.hourPickerClickLabel
@@ -43,12 +43,14 @@ class HourPickerOption : UiFieldOption {
     @Composable
     override fun Composable(modifier: Modifier) {
         val collectedIsPickedVisible by isPickerVisible.collectAsState()
-        TrailingAction(
-            image = hourPickerData.icon,
-            onClick = { isPickerVisible.value = true },
-            contentDescription = null,
-            modifier = modifier,
-        )
+        if (enabled) {
+            TrailingAction(
+                image = hourPickerData.icon,
+                onClick = { isPickerVisible.value = true },
+                contentDescription = null,
+                modifier = modifier,
+            )
+        }
         if (collectedIsPickedVisible) {
             UiFieldTimePicker(
                 onDismiss = { isPickerVisible.value = false },


### PR DESCRIPTION
## 📜 Description

If the date or date&Time field were disabled, the user could still click on the option and display the date (or time) picker dialog. 
This PR hide the options if the field is disabled or readOnly


## 💡 Motivation and Context

## 💚 How did you test it?

- Run the app 
- Navigate to the UIField screen
- Check the "Disabled date field"

## 📝 Checklist
* [ ] I reviewed the submitted code
* [ ] I launched `./gradlew detekt`
* [ ] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
