### PR TITLE
Feature/screenshot dir getter

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2025-05-13
+
+### LbcAndroidTest : 1.11.0
+
+- Add `getScreenshotDir` fun on `LbcPrintRule` to give a direct access to the screenshot directory
+
 ## 2025-05-07
 
 ### LbcUiField-PhonePicker : 1.1.0

--- a/app/src/androidTest/kotlin/studio/lunabee/compose/demo/PrintRuleDemoTest.kt
+++ b/app/src/androidTest/kotlin/studio/lunabee/compose/demo/PrintRuleDemoTest.kt
@@ -66,4 +66,10 @@ class PrintRuleDemoTest : LbcComposeTest() {
     //            .waitUntilExactlyOneExists()
     //            .assertIsDisplayed()
     //    }
+
+    @Test
+    fun getScreenshotDir_exists_test(): Unit = invoke {
+        val dir = printRule.getScreenshotDir()
+        assertTrue(dir.exists())
+    }
 }

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -37,7 +37,7 @@ object AndroidConfig {
     // ⚠️ Match module name in UPPER_CASE ('-' -> '_')
     const val LBCCORE_VERSION: String = "1.8.0"
     const val LBCFOUNDATION_VERSION: String = "1.9.0"
-    const val LBCANDROIDTEST_VERSION: String = "1.10.0"
+    const val LBCANDROIDTEST_VERSION: String = "1.11.0"
     const val LBCACCESSIBILITY_VERSION: String = "1.11.0"
     const val LBCTHEME_VERSION: String = "1.7.0"
     const val MATERIAL_COLOR_UTILITIES_VERSION: String = "1.7.0"

--- a/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/rule/LbcPrintRule.kt
+++ b/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/rule/LbcPrintRule.kt
@@ -75,6 +75,8 @@ class LbcPrintRule(
     private lateinit var appFolder: File
     private lateinit var classFolder: File
 
+    private lateinit var screenshotFolder: File
+
     lateinit var basePath: String
         private set
 
@@ -88,7 +90,7 @@ class LbcPrintRule(
 
         val context = InstrumentationRegistry.getInstrumentation().targetContext
 
-        val screenshotFolder = if (usePublicStorage) {
+        screenshotFolder = if (usePublicStorage) {
             val publicDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
             File(publicDirectory, "lbc_screenshots")
         } else {
@@ -150,6 +152,11 @@ class LbcPrintRule(
         }
 
         bitmap?.let { print(it, suffix) }
+    }
+
+    fun getScreenshotDir(): File {
+        screenshotFolder.mkdirs()
+        return screenshotFolder
     }
 
     override fun succeeded(description: Description?) {


### PR DESCRIPTION
## 📜 Description

- Add `getScreenshotDir` fun on `LbcPrintRule` to give a direct access to the screenshot directory

## 💡 Motivation and Context

- In AuraCam test I want to print some bitmap and be able to retrieve them in the Ci artifacts, which automatically pull files from screenshot dir used by LbcPrintRule. But I dont want the whole naming and compression, so I can't use the existing `print` function

## 💚 How did you test it?

- Unit test

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt`
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
