### PR TITLE
Migrate to context parameters

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,7 +9,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### All
 
-- Migrate from context receiver to context parameters
+```
+LbcAndroidTest 1.12.0
+LbcUiFieldCore 1.8.0
+LbcUiFieldPhonePicker 1.2.0
+LbcUiFieldCountryPicker 1.1.0
+LbcPresenter 1.5.0
+```
+
+- **Breaking:** Migrate from context receiver to context parameters
 
 ## 2025-05-15
 
@@ -43,7 +51,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### LbcUiField : 1.7.0
 
 - **Breaking:** Move all module code into a `core` module. Clients should now import  `studio.lunabee.compose:lbcuifield-core`
-- **Breaking** : Make the `placeholder` and `label` fields nullable for `UiField`
+- **Breaking:** Make the `placeholder` and `label` fields nullable for `UiField`
 
 ### LbcUiField-PhonePicker : 1.0.0
 
@@ -120,7 +128,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 2024-06-27
 
-``` lbcCore = "1.4.0"    
+``` 
+lbcCore = "1.4.0"    
 lbcFoundation = "1.3.0"    
 lbcAndroidTest = "1.2.0"    
 lbcAccessibility = "1.7.0"    

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres    
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2025-07-03
+
+### All
+
+- Migrate from context receiver to context parameters
+
 ## 2025-05-15
 
 ### All

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,8 +77,12 @@ android {
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
     }
+}
 
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-parameters")
+    }
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/AndroidConfig.kt
@@ -36,17 +36,17 @@ object AndroidConfig {
     // ⚠️ Match module name in UPPER_CASE ('-' -> '_')
     const val LBCCORE_VERSION: String = "1.8.0"
     const val LBCFOUNDATION_VERSION: String = "1.9.0"
-    const val LBCANDROIDTEST_VERSION: String = "1.11.1"
+    const val LBCANDROIDTEST_VERSION: String = "1.12.0"
     const val LBCACCESSIBILITY_VERSION: String = "1.11.0"
     const val LBCTHEME_VERSION: String = "1.7.0"
     const val MATERIAL_COLOR_UTILITIES_VERSION: String = "1.7.0"
     const val LBCHAPTIC_VERSION: String = "1.5.0"
-    const val LBCUIFIELD_CORE_VERSION: String = "1.7.0"
-    const val LBCUIFIELD_PHONEPICKER_VERSION: String = "1.1.0"
-    const val LBCUIFIELD_COUNTRYPICKER_VERSION: String = "1.0.0"
+    const val LBCUIFIELD_CORE_VERSION: String = "1.8.0"
+    const val LBCUIFIELD_PHONEPICKER_VERSION: String = "1.2.0"
+    const val LBCUIFIELD_COUNTRYPICKER_VERSION: String = "1.1.0"
     const val LBCIMAGE_VERSION: String = "1.4.0"
     const val LBCGLANCE_VERSION: String = "1.3.0"
-    const val LBCPRESENTER_VERSION: String = "1.4.0"
+    const val LBCPRESENTER_VERSION: String = "1.5.0"
     const val LBCPRESENTER_KOIN_VERSION: String = LBCPRESENTER_VERSION
 
     val JDK_VERSION: JavaVersion = JavaVersion.VERSION_17

--- a/lbcandroidtest/build.gradle.kts
+++ b/lbcandroidtest/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     resourcePrefix("lbc_at_")
     namespace = "studio.lunabee.compose.androidtest"
 
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
+    kotlinOptions.freeCompilerArgs += "-Xcontext-parameters"
 }
 
 description = "Tools for developing android test"

--- a/lbcandroidtest/build.gradle.kts
+++ b/lbcandroidtest/build.gradle.kts
@@ -27,8 +27,12 @@ plugins {
 android {
     resourcePrefix("lbc_at_")
     namespace = "studio.lunabee.compose.androidtest"
+}
 
-    kotlinOptions.freeCompilerArgs += "-Xcontext-parameters"
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xcontext-parameters")
+    }
 }
 
 description = "Tools for developing android test"

--- a/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/LbcComposeTest.kt
+++ b/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/LbcComposeTest.kt
@@ -101,7 +101,7 @@ abstract class LbcComposeTest {
         }
     }
 
-    context(ComposeUiTest)
+    context(composeTest: ComposeUiTest)
     open fun onFailure(e: Throwable) {
         val suffix = LbcAndroidTestConstants.FailureSuffix + "_${e.javaClass.simpleName}"
         printRule.printWholeScreen(suffix, noSync = true)

--- a/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
+++ b/lbcandroidtest/src/main/kotlin/studio/lunabee/compose/androidtest/extension/SemanticMatcherExt.kt
@@ -28,7 +28,7 @@ import kotlin.time.Duration
  *     .waitUntilDoesNotExist(this, false, 1.seconds)
  * ```
  */
-context(ComposeUiTest)
+context(composeTest: ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitUntilDoesNotExist(
     useUnmergedTree: Boolean = false,
@@ -54,7 +54,7 @@ fun SemanticsMatcher.waitUntilDoesNotExist(
  *     .assertIdDisplayed() // additional check
  * ```
  */
-context(ComposeUiTest)
+context(composeTest: ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitUntilExactlyOneExists(
     useUnmergedTree: Boolean = false,
@@ -80,7 +80,7 @@ fun SemanticsMatcher.waitUntilExactlyOneExists(
  *     .assertIdDisplayed() // additional check
  * ```
  */
-context(ComposeUiTest)
+context(composeTest: ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitUntilNodeCount(
     count: Int,
@@ -89,10 +89,10 @@ fun SemanticsMatcher.waitUntilNodeCount(
 ): SemanticsNodeInteractionCollection {
     // Method copy from ComposeUiTest.waitUntilNodeCount to add useUnmergedTree.
     // Waiting for answer: https://issuetracker.google.com/issues/268432145
-    waitUntil("exactly $count nodes match (${this.description})", timeout.inWholeMilliseconds) {
-        onAllNodes(this, useUnmergedTree).fetchSemanticsNodes().size == count
+    composeTest.waitUntil("exactly $count nodes match (${this.description})", timeout.inWholeMilliseconds) {
+        composeTest.onAllNodes(this, useUnmergedTree).fetchSemanticsNodes().size == count
     }
-    return onAllNodes(this, useUnmergedTree)
+    return composeTest.onAllNodes(this, useUnmergedTree)
 }
 
 /**
@@ -110,7 +110,7 @@ fun SemanticsMatcher.waitUntilNodeCount(
  *     .assertIdDisplayed() // additional check
  * ```
  */
-context(ComposeUiTest)
+context(composeTest: ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitUntilAtLeastOneExists(
     useUnmergedTree: Boolean = false,
@@ -118,10 +118,10 @@ fun SemanticsMatcher.waitUntilAtLeastOneExists(
 ): SemanticsNodeInteractionCollection {
     // Method copy from ComposeUiTest.waitUntilExactlyOneExists to add useUnmergedTree.
     // Waiting for answer: https://issuetracker.google.com/issues/268432145
-    waitUntil("at least one node matches (${this.description})", timeout.inWholeMilliseconds) {
-        onAllNodes(this, useUnmergedTree).fetchSemanticsNodes().isNotEmpty()
+    composeTest.waitUntil("at least one node matches (${this.description})", timeout.inWholeMilliseconds) {
+        composeTest.onAllNodes(this, useUnmergedTree).fetchSemanticsNodes().isNotEmpty()
     }
-    return onAllNodes(this, useUnmergedTree)
+    return composeTest.onAllNodes(this, useUnmergedTree)
 }
 
 /**
@@ -140,7 +140,7 @@ fun SemanticsMatcher.waitUntilAtLeastOneExists(
  *     .performClick() // additional check
  * ```
  */
-context(ComposeUiTest)
+context(composeTest: ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitAndPrintRootToCacheDir(
     printRule: LbcPrintRule,
@@ -150,13 +150,13 @@ fun SemanticsMatcher.waitAndPrintRootToCacheDir(
 ): SemanticsNodeInteraction {
     return try {
         waitUntilExactlyOneExists(useUnmergedTree, timeout)
-        printRoot(useUnmergedTree, printRule, suffix)
-        onNode(this)
+        composeTest.printRoot(useUnmergedTree, printRule, suffix)
+        composeTest.onNode(this)
     } catch (e: ComposeTimeoutException) {
-        printRoot(useUnmergedTree = useUnmergedTree, printRule, "${suffix}${LbcAndroidTestConstants.TimeoutSuffix}")
+        composeTest.printRoot(useUnmergedTree = useUnmergedTree, printRule, "${suffix}${LbcAndroidTestConstants.TimeoutSuffix}")
         throw e
     } catch (e: AssertionError) {
-        printRoot(useUnmergedTree = useUnmergedTree, printRule, "${suffix}${LbcAndroidTestConstants.ErrorSuffix}")
+        composeTest.printRoot(useUnmergedTree = useUnmergedTree, printRule, "${suffix}${LbcAndroidTestConstants.ErrorSuffix}")
         throw e
     }
 }
@@ -192,7 +192,7 @@ private fun ComposeUiTest.printRoot(
  *     .waitAndPrintWholeScreenToCacheDir(composeUiTest, printRule, "_suffix", false, 1.seconds)
  * ```
  */
-context(ComposeUiTest)
+context(composeTest: ComposeUiTest)
 @OptIn(ExperimentalTestApi::class)
 fun SemanticsMatcher.waitAndPrintWholeScreenToCacheDir(
     printRule: LbcPrintRule,
@@ -203,7 +203,7 @@ fun SemanticsMatcher.waitAndPrintWholeScreenToCacheDir(
     return try {
         waitUntilAtLeastOneExists(useUnmergedTree, timeout)
         printRule.printWholeScreen(suffix = suffix)
-        onAllNodes(this).filterToOne(this)
+        composeTest.onAllNodes(this).filterToOne(this)
     } catch (e: ComposeTimeoutException) {
         printRule.printWholeScreen(suffix = "${suffix}${LbcAndroidTestConstants.TimeoutSuffix}")
         throw e

--- a/lbccore/build.gradle.kts
+++ b/lbccore/build.gradle.kts
@@ -33,6 +33,12 @@ android {
     }
 }
 
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
+    }
+}
+
 description = "A set of tools for Compose"
 version = AndroidConfig.LBCCORE_VERSION
 

--- a/lbcpresenter/lbcpresenter/build.gradle.kts
+++ b/lbcpresenter/lbcpresenter/build.gradle.kts
@@ -31,9 +31,6 @@ android {
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-
-    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
 }
 
 description = "Compose implementation of MVI pattern"

--- a/lbcuifield/lbcuifield-core/build.gradle.kts
+++ b/lbcuifield/lbcuifield-core/build.gradle.kts
@@ -32,9 +32,6 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
     }

--- a/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/PasswordUiTextField.kt
+++ b/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/PasswordUiTextField.kt
@@ -68,7 +68,7 @@ class PasswordUiTextField(
     }
 
     override val options: List<UiFieldOption> = listOf(
-        PasswordVisibilityFieldOption(),
+        PasswordVisibilityFieldOption(this),
     )
 
     @Composable

--- a/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/option/password/PasswordVisibilityFieldOption.kt
+++ b/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/text/option/password/PasswordVisibilityFieldOption.kt
@@ -29,27 +29,26 @@ import studio.lunabee.compose.core.LbcTextSpec
 import studio.lunabee.compose.foundation.uifield.UiFieldOption
 import studio.lunabee.compose.foundation.uifield.composable.TrailingAction
 
-context(PasswordVisibilityOptionHolder)
-class PasswordVisibilityFieldOption : UiFieldOption {
+class PasswordVisibilityFieldOption(private val holder: PasswordVisibilityOptionHolder) : UiFieldOption {
 
-    override fun onClick(): Unit = onVisibilityToggle()
+    override fun onClick(): Unit = holder.onVisibilityToggle()
 
     override val clickLabel: LbcTextSpec
         get() {
-            return if (isValueVisible.value) {
-                visibilityOptionData.hidePasswordClickLabel
+            return if (holder.isValueVisible.value) {
+                holder.visibilityOptionData.hidePasswordClickLabel
             } else {
-                visibilityOptionData.showPasswordClickLabel
+                holder.visibilityOptionData.showPasswordClickLabel
             }
         }
 
     @Composable
     override fun Composable(modifier: Modifier) {
-        val valueVisible by isValueVisible.collectAsState()
+        val valueVisible by holder.isValueVisible.collectAsState()
         val image = if (valueVisible) {
-            visibilityOptionData.hideIcon
+            holder.visibilityOptionData.hideIcon
         } else {
-            visibilityOptionData.showIcon
+            holder.visibilityOptionData.showIcon
         }
 
         TrailingAction(

--- a/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateAndHourUiField.kt
+++ b/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateAndHourUiField.kt
@@ -62,8 +62,8 @@ class DateAndHourUiField(
     override val enabled: Boolean = true,
 ) : TimeUiField<LocalDateTime?>(), HourPickerHolder, DatePickerHolder {
     override val options: List<UiFieldOption> = listOf(
-        DatePickerOption(enabled && !readOnly),
-        HourPickerOption(enabled && !readOnly),
+        DatePickerOption(enabled && !readOnly, this),
+        HourPickerOption(enabled && !readOnly, this),
     )
 
     override fun savedValueToData(value: String): LocalDateTime {

--- a/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateUiField.kt
+++ b/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/DateUiField.kt
@@ -56,7 +56,7 @@ class DateUiField(
     override val readOnly: Boolean = false,
     override val enabled: Boolean = true,
 ) : TimeUiField<LocalDate?>(), DatePickerHolder {
-    override val options: List<UiFieldOption> = listOf(DatePickerOption(enabled && !readOnly))
+    override val options: List<UiFieldOption> = listOf(DatePickerOption(enabled && !readOnly, this))
     override fun savedValueToData(value: String): LocalDate {
         return LocalDate.parse(value)
     }

--- a/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/date/DatePickerOption.kt
+++ b/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/date/DatePickerOption.kt
@@ -31,13 +31,13 @@ import studio.lunabee.compose.core.LbcTextSpec
 import studio.lunabee.compose.foundation.uifield.UiFieldOption
 import studio.lunabee.compose.foundation.uifield.composable.TrailingAction
 
-context(DatePickerHolder)
 class DatePickerOption(
     private val enabled: Boolean,
+    private val holder: DatePickerHolder
 ) : UiFieldOption {
     private val isPickerVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
-    override val clickLabel: LbcTextSpec = datePickerData.datePickerClickLabel
+    override val clickLabel: LbcTextSpec = holder.datePickerData.datePickerClickLabel
 
     override fun onClick() {
         isPickerVisible.value = true
@@ -49,7 +49,7 @@ class DatePickerOption(
         val collectedIsPickedVisible by isPickerVisible.collectAsState()
         if (enabled) {
             TrailingAction(
-                image = datePickerData.icon,
+                image = holder.datePickerData.icon,
                 onClick = { isPickerVisible.value = true },
                 contentDescription = null,
                 modifier = modifier,
@@ -57,12 +57,12 @@ class DatePickerOption(
         }
         if (collectedIsPickedVisible) {
             UiFieldDatePicker(
-                date = date,
+                date = holder.date,
                 onDismiss = { isPickerVisible.value = false },
-                onValueChanged = ::onValueDateChanged,
-                cancelLabel = datePickerData.datePickerCancelLabel,
-                confirmLabel = datePickerData.datePickerConfirmLabel,
-                selectableDates = selectableDates,
+                onValueChanged = holder::onValueDateChanged,
+                cancelLabel = holder.datePickerData.datePickerCancelLabel,
+                confirmLabel = holder.datePickerData.datePickerConfirmLabel,
+                selectableDates = holder.selectableDates,
             )
         }
     }

--- a/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/hour/HourPickerOption.kt
+++ b/lbcuifield/lbcuifield-core/src/main/kotlin/studio/lunabee/compose/foundation/uifield/field/time/option/hour/HourPickerOption.kt
@@ -30,11 +30,10 @@ import studio.lunabee.compose.core.LbcTextSpec
 import studio.lunabee.compose.foundation.uifield.UiFieldOption
 import studio.lunabee.compose.foundation.uifield.composable.TrailingAction
 
-context(HourPickerHolder)
-class HourPickerOption(private val enabled: Boolean) : UiFieldOption {
+class HourPickerOption(private val enabled: Boolean, private val holder: HourPickerHolder) : UiFieldOption {
     private val isPickerVisible: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
-    override val clickLabel: LbcTextSpec = hourPickerData.hourPickerClickLabel
+    override val clickLabel: LbcTextSpec = holder.hourPickerData.hourPickerClickLabel
 
     override fun onClick() {
         isPickerVisible.value = true
@@ -45,7 +44,7 @@ class HourPickerOption(private val enabled: Boolean) : UiFieldOption {
         val collectedIsPickedVisible by isPickerVisible.collectAsState()
         if (enabled) {
             TrailingAction(
-                image = hourPickerData.icon,
+                image = holder.hourPickerData.icon,
                 onClick = { isPickerVisible.value = true },
                 contentDescription = null,
                 modifier = modifier,
@@ -54,11 +53,11 @@ class HourPickerOption(private val enabled: Boolean) : UiFieldOption {
         if (collectedIsPickedVisible) {
             UiFieldTimePicker(
                 onDismiss = { isPickerVisible.value = false },
-                hour = dateTime?.hour ?: 0,
-                minutes = dateTime?.minute ?: 0,
-                onValueChanged = ::onValueTimeChanged,
-                confirmLabel = hourPickerData.hourPickerConfirmLabel,
-                cancelLabel = hourPickerData.hourPickerCancelLabel,
+                hour = holder.dateTime?.hour ?: 0,
+                minutes = holder.dateTime?.minute ?: 0,
+                onValueChanged = holder::onValueTimeChanged,
+                confirmLabel = holder.hourPickerData.hourPickerConfirmLabel,
+                cancelLabel = holder.hourPickerData.hourPickerCancelLabel,
             )
         }
     }

--- a/lbcuifield/lbcuifield-countrypicker/build.gradle.kts
+++ b/lbcuifield/lbcuifield-countrypicker/build.gradle.kts
@@ -33,9 +33,6 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
     }

--- a/lbcuifield/lbcuifield-countrypicker/src/main/kotlin/studio/lunabee/compose/foundation/uifield/countrypicker/CountryPickerUiField.kt
+++ b/lbcuifield/lbcuifield-countrypicker/src/main/kotlin/studio/lunabee/compose/foundation/uifield/countrypicker/CountryPickerUiField.kt
@@ -72,7 +72,7 @@ class CountryPickerUiField(
     private val trailingIcon: @Composable (() -> Unit)? = null,
 ) : UiField<CountryFieldData>() {
 
-    private val json = Json { }
+    private val json = Json.Default
 
     override val options: List<UiFieldOption> = emptyList()
 

--- a/lbcuifield/lbcuifield-phonepicker/build.gradle.kts
+++ b/lbcuifield/lbcuifield-phonepicker/build.gradle.kts
@@ -33,9 +33,6 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
-    kotlinOptions.freeCompilerArgs += "-Xcontext-receivers"
-
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
     }

--- a/lbcuifield/lbcuifield-phonepicker/src/main/kotlin/studio/lunabee/compose/foundation/uifield/phonepicker/PhonePickerUiField.kt
+++ b/lbcuifield/lbcuifield-phonepicker/src/main/kotlin/studio/lunabee/compose/foundation/uifield/phonepicker/PhonePickerUiField.kt
@@ -75,7 +75,7 @@ class PhonePickerUiField(
     private val countryPickerBottomSheetRenderer: CountryPickerBottomSheetRenderer,
 ) : UiField<CountryCodeFieldData>() {
 
-    private val json = Json { }
+    private val json = Json.Default
 
     override val options: List<UiFieldOption> = emptyList()
 


### PR DESCRIPTION
## 📜 Description

- Migrate from context receiver to context parameters

## 💡 Motivation and Context

- Allow to use lbcandroidtest without optin to deprecated context receiver

## 💚 How did you test it?

- Ci
- Build & run

## 📝 Checklist
* [x] I reviewed the submitted code
* [x] I launched `./gradlew detekt` **-> without formatting** https://github.com/detekt/detekt/issues/8140
* [x] I filled the [changelog](https://github.com/LunabeeStudio/Lunabee-Compose-Android/blob/develop/CHANGELOG.MD)

## 🔮 Next steps

## 📸 Screenshots / GIFs
